### PR TITLE
Update CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,56 +1,13 @@
-# Code of Conduct
+# Contributor Code of Conduct
 
-The Justice40 community is dedicated to providing a harassment-free experience for everyone, regardless of gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, or religion. We do not tolerate harassment of participants in any form.
+As contributors and maintainers of this project, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities.
 
-This code of conduct applies to all Justice sponsored spaces. Anyone who violates this code of conduct may be sanctioned or expelled from these spaces at the discretion of the Justice40 Team.
+We are committed to making participation in this project a harassment-free experience for everyone, regardless of level of experience, gender, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, or religion.
 
-Some Justice40-sponsored spaces may have additional rules in place, which will be made clearly available to participants. Participants are responsible for knowing and abiding by these rules.
+Examples of unacceptable behavior by participants include the use of sexual language or imagery, derogatory comments or personal attacks, trolling, public or private harassment, insults, or other unprofessional conduct.
 
-## Definitions
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct.
 
-Harassment includes:
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by opening an issue or contacting one or more of the project maintainers at justice40open@usds.gov.
 
-- Offensive comments related to gender, gender identity and expression, sexual orientation, disability, mental illness, neuro(a)typicality, physical appearance, body size, race, or religion
-- Unwelcome comments regarding a person’s lifestyle choices and practices, including those related to food, health, parenting, drugs, and employment.
-- Deliberate misgendering or use of ‘dead’ or rejected names
-- Gratuitous or off-topic sexual images or behaviour in spaces where they’re not appropriate
-- Physical contact and simulated physical contact (eg, textual descriptions like “_hug_” or “_backrub_”) without consent or after a request to stop.
-- Threats of violence
-- Incitement of violence towards any individual, including encouraging a person to commit suicide or to engage in self-harm
-- Deliberate intimidation
-- Stalking or following
-- Harassing photography or recording, including logging online activity for harassment purposes
-- Sustained disruption of discussion
-- Unwelcome sexual attention
-- Pattern of inappropriate social contact, such as requesting/assuming inappropriate levels of intimacy with others
-- Continued one-on-one communication after requests to cease
-- Deliberate “outing” of any aspect of a person’s identity without their consent except as necessary to protect other Justice40 members or other vulnerable people from intentional abuse
-- Publication of non-harassing private communication
-
-The Justice40 community prioritizes marginalized people’s safety over privileged people’s comfort. The Justice40 Team will not act on complaints regarding:
-
-- ‘Reverse’ -isms, including ‘reverse racism,’ ‘reverse sexism,’ and ‘cisphobia’ (because these things don’t exist)
-- Reasonable communication of boundaries, such as “leave me alone,” “go away,” or “I’m not discussing this with you.”
-- Refusal to explain or debate social justice concepts
-- Communicating in a ‘tone’ you don’t find congenial
-- Criticizing racist, sexist, cissexist, or otherwise oppressive behavior or assumptions
-
-## Reporting
-
-If you are being harassed by a member of the Justice40 community, notice that someone else is being harassed, or have any other concerns, please contact the Justice40 Team. If the person who is harassing you is on the team, they will recuse themselves from handling your incident. We will respond as promptly as we can.
-
-This code of conduct applies to Justice40 sponsored spaces, but if you are being harassed by a member of the Justice40 community outside our spaces, we still want to know about it. We will take all good-faith reports of harassment by Justice40 community members, especially bloggers, seriously. This includes harassment outside our spaces and harassment that took place at any point in time.The abuse team reserves the right to exclude people from the Justice40 community based on their past behavior, including behavior outside Justice40 spaces and behavior towards people who are not in the Justice40 community.
-
-In order to protect volunteers from abuse and burnout, we reserve the right to reject any report we believe to have been made in bad faith. The Justice40 Team is not here to explain power differentials or other basic social justice concepts to you. Reports intended to silence legitimate criticism may be deleted without response.
-
-We will respect confidentiality requests for the purpose of protecting victims of abuse. At our discretion, we may publicly name a person about whom we’ve received harassment complaints, or privately warn third parties about them, if we believe that doing so will increase the safety of Justice40 members or the general public. We will not name harassment victims without their affirmative consent.
-
-## Consequences
-
-Participants asked to stop any harassing behavior are expected to comply immediately.
-
-If a participant engages in harassing behavior, the Justice40 Team may take any action they deem appropriate, up to and including expulsion from all Justice40 spaces and identification of the participant as a harasser to other Justice40 members or the general public.
-
-# Adopt a code of conduct in your community
-
-This anti-harassment policy is based on the example policy from the [Geek Feminism wiki](https://geekfeminism.wikia.org/wiki/Community_anti-harassment), created by the Geek Feminism community.
+This Code of Conduct is adapted from the [Contributor Covenant](http://contributor-covenant.org), version 1.0.0, available at [http://contributor-covenant.org/version/1/0/0/](http://contributor-covenant.org/version/1/0/0/)


### PR DESCRIPTION
Use code of conduct from VA project: https://github.com/department-of-veterans-affairs/va_common/blob/b3ceb03807273b093bc5003e345d96867deab5e4/CODE_OF_CONDUCT.md

The reason for the change is to start with an already approved-for-government code of conduct and add language incrementally as needed with review.