### PR TITLE
Fix 'Peer authentication failed' error flooding in pg_isready

### DIFF
--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -11,6 +11,7 @@ services:
     ports:
       - 7800:7800
     restart: unless-stopped
+
   db:
     image: kartoza/postgis:13-3.1
     volumes:
@@ -25,10 +26,11 @@ services:
     ports:
       - 5434:5432
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U map_dev_user -d map_dev"]
+      test: ["CMD-SHELL", "pg_isready -h db -U map_dev_user -d map_dev"]
       interval: 5s
       timeout: 5s
       retries: 5
     restart: unless-stopped
+
 volumes:
   pgdata:


### PR DESCRIPTION
Fixes error flooding as follows:

```
db_1        | 2021-05-15 00:49:18.730 UTC [357] map_dev_user@map_dev LOG:  provided user name (map_dev_user) and authenticated user name (root) do not match
db_1        | 2021-05-15 00:49:18.730 UTC [357] map_dev_user@map_dev FATAL:  Peer authentication failed for user "map_dev_user"
db_1        | 2021-05-15 00:49:18.730 UTC [357] map_dev_user@map_dev DETAIL:  Connection matched pg_hba.conf line 94: "local   all             all                                     peer"
db_1        | 2021-05-15 00:49:23.857 UTC [365] map_dev_user@map_dev LOG:  provided user name (map_dev_user) and authenticated user name (root) do not match
db_1        | 2021-05-15 00:49:23.857 UTC [365] map_dev_user@map_dev FATAL:  Peer authentication failed for user "map_dev_user"
db_1        | 2021-05-15 00:49:23.857 UTC [365] map_dev_user@map_dev DETAIL:  Connection matched pg_hba.conf line 94: "local   all             all                                     peer"
db_1        | 2021-05-15 00:49:28.979 UTC [373] map_dev_user@map_dev LOG:  provided user name (map_dev_user) and authenticated user name (root) do not match
db_1        | 2021-05-15 00:49:28.979 UTC [373] map_dev_user@map_dev FATAL:  Peer authentication failed for user "map_dev_user"
db_1        | 2021-05-15 00:49:28.979 UTC [373] map_dev_user@map_dev DETAIL:  Connection matched pg_hba.conf line 94: "local   all             all                                     peer"
db_1        | 2021-05-15 00:49:34.088 UTC [381] map_dev_user@map_dev LOG:  provided user name (map_dev_user) and authenticated user name (root) do not match
db_1        | 2021-05-15 00:49:34.088 UTC [381] map_dev_user@map_dev FATAL:  Peer authentication failed for user "map_dev_user"
db_1        | 2021-05-15 00:49:34.088 UTC [381] map_dev_user@map_dev DETAIL:  Connection matched pg_hba.conf line 94: "local   all             all                                     peer"
db_1        | 2021-05-15 00:49:39.199 UTC [390] map_dev_user@map_dev LOG:  provided user name (map_dev_user) and authenticated user name (root) do not match
db_1        | 2021-05-15 00:49:39.200 UTC [390] map_dev_user@map_dev FATAL:  Peer authentication failed for user "map_dev_user"
db_1        | 2021-05-15 00:49:39.200 UTC [390] map_dev_user@map_dev DETAIL:  Connection matched pg_hba.conf line 94: "local   all             all                                     peer"
db_1        | 2021-05-15 00:49:44.326 UTC [398] map_dev_user@map_dev LOG:  provided user name (map_dev_user) and authenticated user name (root) do not match
db_1        | 2021-05-15 00:49:44.326 UTC [398] map_dev_user@map_dev FATAL:  Peer authentication failed for user "map_dev_user"
db_1        | 2021-05-15 00:49:44.326 UTC [398] map_dev_user@map_dev DETAIL:  Connection matched pg_hba.conf line 94: "local   all             all                                     peer"
db_1        | 2021-05-15 00:49:49.442 UTC [407] map_dev_user@map_dev LOG:  provided user name (map_dev_user) and authenticated user name (root) do not match
db_1        | 2021-05-15 00:49:49.442 UTC [407] map_dev_user@map_dev FATAL:  Peer authentication failed for user "map_dev_user"
db_1        | 2021-05-15 00:49:49.442 UTC [407] map_dev_user@map_dev DETAIL:  Connection matched pg_hba.conf line 94: "local   all             all                                     peer"
db_1        | 2021-05-15 00:49:54.571 UTC [415] map_dev_user@map_dev LOG:  provided user name (map_dev_user) and authenticated user name (root) do not match
db_1        | 2021-05-15 00:49:54.572 UTC [415] map_dev_user@map_dev FATAL:  Peer authentication failed for user "map_dev_user"
db_1        | 2021-05-15 00:49:54.572 UTC [415] map_dev_user@map_dev DETAIL:  Connection matched pg_hba.conf line 94: "local   all             all                                     peer"
```