### PR TITLE
Update compile_mermaid.yml

### DIFF
--- a/.github/workflows/compile_mermaid.yml
+++ b/.github/workflows/compile_mermaid.yml
@@ -42,8 +42,8 @@ jobs:
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-          git add .
-          git commit -m "Add changes" -a
+          git add -A
+          git diff-index --quiet HEAD || git commit -a -m 'Updating Diagram'
 
       - name: Push Changes
         uses: ad-m/github-push-action@master


### PR DESCRIPTION
Our mermaid-compiling github action currently fails with an exit code of 1 if it attempts to commit files but there haven't been any changes. We should be resilient to this by checking the exit code of `git diff-index`