### PR TITLE
Fixes Geoplatform AWS errors on load

### DIFF
--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -72,4 +72,4 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
       - name: Deploy to Geoplatform AWS
-        run: aws s3 sync ./public/ s3://usds-geoplatform-justice40-website --delete
+        run: aws s3 sync ./public/ s3://usds-geoplatform-justice40-website/justice40-tool --delete


### PR DESCRIPTION
Fixes issue #107 Geoplatform AWS throws errors on load - we had configured a prefix-path for use with github pages, but this didn't match the path within the s3 bucket. Upload content to a subfolder and ensure users access site from /justice40-tool/ . 

Additional benefit is that this fixes our CloudFront rendering, provided you supply this portion: https://d2zjid6n5ja2pt.cloudfront.net/justice40-tool/en/ now works to vend our latest site over https!