### PR TITLE
Adding SHA (for PRs)/ Main (for main) to URL 

### DIFF
--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -29,9 +29,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
       # If this is just a PR branch, put content in a hash directory. Otherwise, put it in "main"
       - name: Set DESTINATION_FOLDER
-        run: echo "DESTINATION_FOLDER=${{ github.event.pull_request.merged == 'true' && 'main' || $SHA_SHORT }}" >> $GITHUB_ENV
-        env:
-          SHA_SHORT: ${{$GITHUB_SHA | cut -c 1-6}}
+        run: echo "DESTINATION_FOLDER=${{ github.event.pull_request.merged == 'true' && 'main' || github.sha | cut -c 1-6 }}" >> $GITHUB_ENV
       - name: Install
         run: npm ci
       - name: Build

--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -64,6 +64,11 @@ jobs:
         with:
           name: J40Static
           path: ./public
+      - name: Set GITHUB_SHA_SHORT
+        run: echo "GITHUB_SHA_SHORT=$(echo $GITHUB_SHA | cut -c 1-6)" >> $GITHUB_ENV
+      # If this is just a PR branch, put content in a hash directory. Otherwise, put it in "main"
+      - name: Set DESTINATION_FOLDER
+        run: echo "DESTINATION_FOLDER=${{ github.event.pull_request.merged == 'true' && 'main' || env.GITHUB_SHA_SHORT }}" >> $GITHUB_ENV
       - name: Deploy to Github Pages
         uses: JamesIves/github-pages-deploy-action@4.1.0
         with:

--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -7,7 +7,7 @@
 name: GH Pages deploy
 env:
   # If this is just a PR branch, put content in a hash directory. Otherwise, put it in "main"
-  DESTINATION_FOLDER: ${{ github.event.pull_request.merged == 'true' && 'main' || ${{env.GITHUB_SHA}} | cut -c1-8 }}
+  DESTINATION_FOLDER: ${{ github.event.pull_request.merged == 'true' && 'main' || ${{GITHUB_SHA}} | cut -c1-8 }}
 on:
   push:
     branches: [main]

--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -27,9 +27,11 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+      - name: Set GITHUB_SHA_SHORT
+        run: echo "GITHUB_SHA_SHORT=$(echo $GITHUB_SHA | cut -c 1-6)" >> $GITHUB_ENV
       # If this is just a PR branch, put content in a hash directory. Otherwise, put it in "main"
       - name: Set DESTINATION_FOLDER
-        run: echo "DESTINATION_FOLDER=${{ github.event.pull_request.merged == 'true' && 'main' || github.sha | cut -c 1-6 }}" >> $GITHUB_ENV
+        run: echo "DESTINATION_FOLDER=${{ github.event.pull_request.merged == 'true' && 'main' || $GITHUB_SHA_SHORT }}" >> $GITHUB_ENV
       - name: Install
         run: npm ci
       - name: Build

--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -5,6 +5,9 @@
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
 name: GH Pages deploy
+env:
+  # If this is just a PR branch, put content in a hash directory. Otherwise, put it in "main"
+  DESTINATION_FOLDER: ${{ github.event.pull_request.merged == 'true' && "main" || env.GITHUB_SHA | cut -c1-8 }}
 on:
   push:
     branches: [main]
@@ -65,6 +68,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: gh-pages # The branch the action should deploy to.
           FOLDER: public # The folder the action should deploy.
+          TARGET-FOLDER: ${{DESTINATION_FOLDER}} # If we're on a PR branch, merge to PR folder
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -72,4 +76,4 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
       - name: Deploy to Geoplatform AWS
-        run: aws s3 sync ./public/ s3://usds-geoplatform-justice40-website/justice40-tool --delete
+        run: aws s3 sync ./public/ s3://usds-geoplatform-justice40-website/justice40-tool/${{DESTINATION_FOLDER}} --delete

--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -31,7 +31,7 @@ jobs:
         run: echo "GITHUB_SHA_SHORT=$(echo $GITHUB_SHA | cut -c 1-6)" >> $GITHUB_ENV
       # If this is just a PR branch, put content in a hash directory. Otherwise, put it in "main"
       - name: Set DESTINATION_FOLDER
-        run: echo "DESTINATION_FOLDER=${{ github.event.pull_request.merged == 'true' && 'main' || $GITHUB_SHA_SHORT }}" >> $GITHUB_ENV
+        run: echo "DESTINATION_FOLDER=${{ github.event.pull_request.merged == 'true' && 'main' || GITHUB_SHA_SHORT }}" >> $GITHUB_ENV
       - name: Install
         run: npm ci
       - name: Build

--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -31,7 +31,7 @@ jobs:
         run: echo "GITHUB_SHA_SHORT=$(echo $GITHUB_SHA | cut -c 1-6)" >> $GITHUB_ENV
       # If this is just a PR branch, put content in a hash directory. Otherwise, put it in "main"
       - name: Set DESTINATION_FOLDER
-        run: echo "DESTINATION_FOLDER=${{ github.event.pull_request.merged == 'true' && 'main' || GITHUB_SHA_SHORT }}" >> $GITHUB_ENV
+        run: echo "DESTINATION_FOLDER=${{ github.event.pull_request.merged == 'true' && 'main' || env.GITHUB_SHA_SHORT }}" >> $GITHUB_ENV
       - name: Install
         run: npm ci
       - name: Build

--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -29,7 +29,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
       # If this is just a PR branch, put content in a hash directory. Otherwise, put it in "main"
       - name: Set DESTINATION_FOLDER
-        run: echo "DESTINATION_FOLDER=${{ github.event.pull_request.merged == 'true' && 'main' || echo $GITHUB_SHA | cut -c 1-6 }}" >> $GITHUB_ENV
+        run: echo "DESTINATION_FOLDER=${{ github.event.pull_request.merged == 'true' && 'main' || $GITHUB_SHA | cut -c 1-6 }}" >> $GITHUB_ENV
       - name: Install
         run: npm ci
       - name: Build

--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -7,7 +7,7 @@
 name: GH Pages deploy
 env:
   # If this is just a PR branch, put content in a hash directory. Otherwise, put it in "main"
-  DESTINATION_FOLDER: ${{ github.event.pull_request.merged == 'true' && 'main' || env.GITHUB_SHA | cut -c1-8 }}
+  DESTINATION_FOLDER: ${{ github.event.pull_request.merged == 'true' && 'main' || ${{env.GITHUB_SHA}} | cut -c1-8 }}
 on:
   push:
     branches: [main]

--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -29,7 +29,9 @@ jobs:
           node-version: ${{ matrix.node-version }}
       # If this is just a PR branch, put content in a hash directory. Otherwise, put it in "main"
       - name: Set DESTINATION_FOLDER
-        run: echo "DESTINATION_FOLDER=${{ github.event.pull_request.merged == 'true' && 'main' || $GITHUB_SHA | cut -c 1-6 }}" >> $GITHUB_ENV
+        run: |
+          SHA_SHORT=$($GITHUB_SHA | cut -c 1-6)
+          echo "DESTINATION_FOLDER=${{ github.event.pull_request.merged == 'true' && 'main' || $SHA_SHORT }}" >> $GITHUB_ENV
       - name: Install
         run: npm ci
       - name: Build

--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -29,7 +29,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
       # If this is just a PR branch, put content in a hash directory. Otherwise, put it in "main"
       - name: Set DESTINATION_FOLDER
-        run: echo "DESTINATION_FOLDER=${{ github.event.pull_request.merged == 'true' && 'main' || $(echo $GITHUB_SHA | cut -c 1-6) }}" >> $GITHUB_ENV
+        run: echo "DESTINATION_FOLDER=${{ github.event.pull_request.merged == 'true' && 'main' || echo $GITHUB_SHA | cut -c 1-6 }}" >> $GITHUB_ENV
       - name: Install
         run: npm ci
       - name: Build

--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -7,7 +7,7 @@
 name: GH Pages deploy
 env:
   # If this is just a PR branch, put content in a hash directory. Otherwise, put it in "main"
-  DESTINATION_FOLDER: ${{ github.event.pull_request.merged == 'true' && "main" || env.GITHUB_SHA | cut -c1-8 }}
+  DESTINATION_FOLDER: ${{ github.event.pull_request.merged == 'true' && 'main' || env.GITHUB_SHA | cut -c1-8 }}
 on:
   push:
     branches: [main]

--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -29,9 +29,9 @@ jobs:
           node-version: ${{ matrix.node-version }}
       # If this is just a PR branch, put content in a hash directory. Otherwise, put it in "main"
       - name: Set DESTINATION_FOLDER
-        run: |
-          SHA_SHORT=$($GITHUB_SHA | cut -c 1-6)
-          echo "DESTINATION_FOLDER=${{ github.event.pull_request.merged == 'true' && 'main' || $SHA_SHORT }}" >> $GITHUB_ENV
+        run: echo "DESTINATION_FOLDER=${{ github.event.pull_request.merged == 'true' && 'main' || $SHA_SHORT }}" >> $GITHUB_ENV
+        env:
+          SHA_SHORT: ${{$GITHUB_SHA | cut -c 1-6}}
       - name: Install
         run: npm ci
       - name: Build

--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -29,7 +29,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
       # If this is just a PR branch, put content in a hash directory. Otherwise, put it in "main"
       - name: Set DESTINATION_FOLDER
-        run: echo "DESTINATION_FOLDER=$(${{ github.event.pull_request.merged == 'true' && 'main' || echo $GITHUB_SHA | cut -c 1-6)" >> $GITHUB_ENV
+        run: echo "DESTINATION_FOLDER=${{ github.event.pull_request.merged == 'true' && 'main' || $(echo $GITHUB_SHA | cut -c 1-6) }}" >> $GITHUB_ENV
       - name: Install
         run: npm ci
       - name: Build

--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -5,9 +5,6 @@
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
 name: GH Pages deploy
-env:
-  # If this is just a PR branch, put content in a hash directory. Otherwise, put it in "main"
-  DESTINATION_FOLDER: ${{ github.event.pull_request.merged == 'true' && 'main' || ${{GITHUB_SHA}} | cut -c1-8 }}
 on:
   push:
     branches: [main]
@@ -30,6 +27,9 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+      # If this is just a PR branch, put content in a hash directory. Otherwise, put it in "main"
+      - name: Set DESTINATION_FOLDER
+        run: echo "DESTINATION_FOLDER=$(${{ github.event.pull_request.merged == 'true' && 'main' || echo $GITHUB_SHA | cut -c 1-6)" >> $GITHUB_ENV
       - name: Install
         run: npm ci
       - name: Build
@@ -68,7 +68,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: gh-pages # The branch the action should deploy to.
           FOLDER: public # The folder the action should deploy.
-          TARGET-FOLDER: ${{DESTINATION_FOLDER}} # If we're on a PR branch, merge to PR folder
+          TARGET-FOLDER: ${{env.DESTINATION_FOLDER}} # If we're on a PR branch, merge to PR folder
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -76,4 +76,4 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
       - name: Deploy to Geoplatform AWS
-        run: aws s3 sync ./public/ s3://usds-geoplatform-justice40-website/justice40-tool/${{DESTINATION_FOLDER}} --delete
+        run: aws s3 sync ./public/ s3://usds-geoplatform-justice40-website/justice40-tool/${{env.DESTINATION_FOLDER}} --delete

--- a/client/gatsby-config.js
+++ b/client/gatsby-config.js
@@ -2,7 +2,7 @@ module.exports = {
   siteMetadata: {
     title: 'Justice40',
   },
-  pathPrefix: '/justice40-tool',
+  pathPrefix: `/justice40-tool/${process.env.DESTINATION_FOLDER}`,
   plugins: [
     {
       resolve: 'gatsby-plugin-sass',


### PR DESCRIPTION
Fixes #90 - adds a GHA SHA to PR branches and 'main' for merges to main

Adds a `DESTINATION_FOLDER` ENV var and consults it for setting prefix path and copying files.
Adding "draft" label for now as I need to prove that it actually works by running it first on GHA

As examples:
1. On PR
http://usds-geoplatform-justice40-website.s3-website-us-east-1.amazonaws.com/justice40-tool/123431/en 
https://d2zjid6n5ja2pt.cloudfront.net/justice40-tool/123431/en


2. On merge to main:
http://usds-geoplatform-justice40-website.s3-website-us-east-1.amazonaws.com/justice40-tool/main/en
https://d2zjid6n5ja2pt.cloudfront.net/justice40-tool/123431/en
