### PR TITLE
fixes prettier error msg during build process

### DIFF
--- a/client/gatsby-config.js
+++ b/client/gatsby-config.js
@@ -39,10 +39,10 @@ module.exports = {
           patterns: [
             // The pattern "**/*.{js,jsx,ts,tsx}" is
             // not used because we will rely on `eslint --fix`
-            '**/*.{css,scss,less}',
-            '**/*.{json,json5}',
+            '**/*.{scss}',
+            '**/*.{json}',
             '**/*.{graphql}',
-            '**/*.{md,mdx}',
+            '**/*.{md}',
             '**/*.{html}',
             '**/*.{yaml,yml}',
           ],


### PR DESCRIPTION
fixes #290 

It was determined that the files that prettier was suppose to _prettify_, was responsible for the error.

The gatsby-config file has a section where we define the files that prettier should [process](https://github.com/usds/justice40-tool/blob/7c9ce4110616eae2b28afb2391e7702dd64dacc0/client/gatsby-config.js#L38), via a `pattern` key. The pattern key is a string that defines various files types at any depth. This config file's prettier section was using the default settings to accommodate the most common file types.

The error was being thrown for the following files types: `json5`, `mdx`, `less`, `css`. When these superfluous files types were removed, the error was also removed.
 
**How was it determined if these patterns were ok to remove?**

Searching the `client` folder for these superfluous files types (except for *.css, which we'll get to shortly) came up null. Meaning there are no files with these extensions in the client folder. My thoughts for removing them is that If we ever start using `json5`, `mdx` or `less` files, we can add them back in, when that time comes.
 
Back to `css` files. When searching for `.css`, 3 instances were found. Namely:
 
1. mapboxMap.tsx - line [14](https://github.com/usds/justice40-tool/blob/7c9ce4110616eae2b28afb2391e7702dd64dacc0/client/src/components/mapboxMap.tsx#L14)
2. mapStyle.tsx - line [7](https://github.com/usds/justice40-tool/blob/7c9ce4110616eae2b28afb2391e7702dd64dacc0/client/src/data/mapStyle.tsx#L7)
3. global.scss - line [26](https://github.com/usds/justice40-tool/blob/7c9ce4110616eae2b28afb2391e7702dd64dacc0/client/src/styles/global.scss#L26)

The first `.css` instance is an import. I don't believe prettier is concerned with the format of this imported file. I believe it's concerned with the `.scss` file in which the import is listed which is why I'm concluding it's ok to remove.

The second `.css` instance is function call in the chroma lib. I don't believe prettier is concerned with this.

The third and last instance is importing the index.css from `@trussworks`. Similar argument as the first instance.

Would love to hear any feedback or errors in my conclusions. 😄 