### PR TITLE
Adding low zoom level styling

### DIFF
--- a/client/cypress/e2e/map.spec.js
+++ b/client/cypress/e2e/map.spec.js
@@ -39,7 +39,7 @@ describe('Tests for the Explore the Map page', () => {
       return map.getFeatureState(
           {
             'id': id,
-            'source': constants.SCORE_SOURCE_NAME,
+            'source': constants.HIGH_SCORE_SOURCE_NAME,
             'sourceLayer': constants.SCORE_SOURCE_LAYER,
           },
       );

--- a/client/src/components/J40Map.tsx
+++ b/client/src/components/J40Map.tsx
@@ -8,7 +8,6 @@ import maplibregl, {LngLatBoundsLike,
   LngLatLike,
   MapboxGeoJSONFeature} from 'maplibre-gl';
 import mapStyle from '../data/mapStyle';
-import ZoomWarning from './zoomWarning';
 import PopupContent from './popupContent';
 import * as constants from '../data/constants';
 import ReactDOM from 'react-dom';
@@ -76,7 +75,7 @@ const J40Map = () => {
     const map = e.target;
     const clickedCoord = e.point;
     const features = map.queryRenderedFeatures(clickedCoord, {
-      layers: ['score'],
+      layers: [constants.HIGH_SCORE_LAYER_NAME],
     });
     const feature = features && features[0];
     if (feature) {
@@ -107,10 +106,10 @@ const J40Map = () => {
     mapRef.current.on('move', () => {
       setZoom(mapRef.current.getZoom());
     });
-    mapRef.current.on('mouseenter', 'score', () => {
+    mapRef.current.on('mouseenter', constants.HIGH_SCORE_LAYER_NAME, () => {
       mapRef.current.getCanvas().style.cursor = 'pointer';
     });
-    mapRef.current.on('mouseleave', 'score', () => {
+    mapRef.current.on('mouseleave', constants.HIGH_SCORE_LAYER_NAME, () => {
       mapRef.current.getCanvas().style.cursor = '';
     });
   }, [mapRef]);
@@ -177,7 +176,6 @@ const J40Map = () => {
         </button>
       </div>
       <div ref={mapContainer} className={styles.mapContainer}/>
-      <ZoomWarning zoomLevel={zoom} />
     </div>
   );
 };

--- a/client/src/data/constants.tsx
+++ b/client/src/data/constants.tsx
@@ -1,13 +1,22 @@
 // URLS
-export const FEATURE_TILE_BASE_URL = 'https://d2zjid6n5ja2pt.cloudfront.net/0629_demo';
+export const FEATURE_TILE_BASE_URL = 'https://d2zjid6n5ja2pt.cloudfront.net';
+const XYZ_SUFFIX = '{z}/{x}/{y}.pbf';
+export const FEATURE_TILE_HIGH_ZOOM_URL = `${FEATURE_TILE_BASE_URL}/0629_demo/${XYZ_SUFFIX}`;
+export const FEATURE_TILE_LOW_ZOOM_URL = `${FEATURE_TILE_BASE_URL}/tiles_low/${XYZ_SUFFIX}`;
+
 
 // Performance markers
 export const PERFORMANCE_MARKER_MAP_IDLE = 'MAP_IDLE';
 
 // Properties
-export const SCORE_PROPERTY = 'Score D (percentile)';
+export const SCORE_PROPERTY_HIGH = 'Score D (percentile)';
+export const SCORE_PROPERTY_LOW = 'D_SCORE';
 export const GEOID_PROPERTY = 'GEOID10';
-export const SCORE_SOURCE_NAME = 'score';
+export const HIGH_SCORE_SOURCE_NAME = 'score-high';
+export const HIGH_SCORE_LAYER_NAME = 'score-high-layer';
+export const LOW_SCORE_SOURCE_NAME = 'score-low';
+export const LOW_SCORE_LAYER_NAME = 'score-low-layer';
+
 // The name of the layer within the tiles that contains the score
 export const SCORE_SOURCE_LAYER = 'blocks';
 
@@ -18,8 +27,10 @@ export type J40Properties = { [key: string]: any };
 export const GLOBAL_MIN_ZOOM = 3;
 export const GLOBAL_MAX_ZOOM = 22;
 export const GLOBAL_MIN_ZOOM_LOW = 3;
-export const GLOBAL_MAX_ZOOM_LOW = 9;
-export const GLOBAL_MIN_ZOOM_HIGH = 9;
+export const GLOBAL_MAX_ZOOM_LOW = 7;
+export const GLOBAL_MIN_ZOOM_HIGHLIGHT = 9;
+export const GLOBAL_MAX_ZOOM_HIGHLIGHT = 22;
+export const GLOBAL_MIN_ZOOM_HIGH = 7;
 export const GLOBAL_MAX_ZOOM_HIGH = 11;
 
 // Bounds
@@ -74,3 +85,13 @@ export const MIN_COLOR = '#FFFFFF';
 export const MED_COLOR = '#D1DAE6';
 export const MAX_COLOR = '#768FB3';
 export const BORDER_HIGHLIGHT_COLOR = '#00BDE3';
+
+// Widths
+export const HIGHLIGHT_BORDER_WIDTH = 5.0;
+
+// Score boundaries
+export const SCORE_BOUNDARY_LOW = 0.0;
+export const SCORE_BOUNDARY_THRESHOLD = 0.6;
+export const SCORE_BOUNDARY_PRIORITIZED = 0.75;
+
+export const isMobile = typeof window !== 'undefined' && (window.innerWidth < 400);

--- a/client/src/data/mapStyle.tsx
+++ b/client/src/data/mapStyle.tsx
@@ -69,6 +69,9 @@ const mapStyle : Style = {
       'maxzoom': constants.GLOBAL_MAX_ZOOM,
     },
     'score-high': {
+      // "Score-high" represents the full set of data
+      // at the census block group level. It is only shown
+      // at high zoom levels to avoid performance issues at lower zooms
       'type': 'vector',
       // Our current tippecanoe command does not set an id.
       // The below line promotes the GEOID10 property to the ID
@@ -83,6 +86,10 @@ const mapStyle : Style = {
       'maxzoom': constants.GLOBAL_MAX_ZOOM_HIGH,
     },
     'score-low': {
+      // "Score-low" represents a tileset at the level of bucketed tracts.
+      // census block group information is `dissolve`d into tracts, then
+      // each tract is `dissolve`d into one of ten buckets. It is meant
+      // to give us a favorable tradeoff between performance and fidelity.
       'type': 'vector',
       'promoteId': constants.GEOID_PROPERTY,
       'tiles': [
@@ -156,6 +163,8 @@ const mapStyle : Style = {
       'maxzoom': constants.GLOBAL_MAX_ZOOM_LOW,
     },
     {
+      // "Score-highlights" represents the border
+      // around given tiles that appears at higher zooms
       'id': 'score-highlights',
       'source': constants.HIGH_SCORE_SOURCE_NAME,
       'source-layer': constants.SCORE_SOURCE_LAYER,
@@ -174,8 +183,8 @@ const mapStyle : Style = {
       'maxzoom': constants.GLOBAL_MAX_ZOOM_HIGHLIGHT,
     },
     {
-      // This layer queries the feature-state property "selected" and
-      // highlights the border of the selected region if true
+      // "score-border-highlight" is used to highlight
+      // the currently-selected feature
       'id': 'score-border-highlight',
       'type': 'line',
       'source': constants.HIGH_SCORE_SOURCE_NAME,
@@ -194,6 +203,7 @@ const mapStyle : Style = {
       'maxzoom': constants.GLOBAL_MAX_ZOOM_HIGH,
     },
     {
+      // We put labels last to ensure prominence
       'id': 'labels-only',
       'type': 'raster',
       'source': 'labels',


### PR DESCRIPTION
Fixes #201 - As an EVCM, I want the map to make sense at varying zoom levels so that I'm not confused . For now uses a usa_low tileset created as part of #209 for zoom levels 3-7. Will need further iteration.

For now uses a usa_low tileset created as part of #209 for zoom levels 3-7. Will need further iteration.