### PR TITLE
Fix inlined css in every single page.

### DIFF
--- a/client/gatsby-ssr.js
+++ b/client/gatsby-ssr.js
@@ -5,13 +5,13 @@
   `ssr` means server-side rendering.
   */
 export const onPreRenderHTML = ({getHeadComponents}) => {
-  if (process.env.NODE_ENV !== 'production') {
+  if (process.env.NODE_ENV !== 'production') { // ONLY run in production
     return;
   }
 
   getHeadComponents().forEach((el) => {
     // Remove inline css. https://github.com/gatsbyjs/gatsby/issues/1526
-    if (el.type === 'style') {
+    if (el.type === 'style' && el.props['data-href']) {
       el.type = 'link';
       el.props['href'] = el.props['data-href'];
       el.props['rel'] = 'stylesheet';

--- a/client/gatsby-ssr.js
+++ b/client/gatsby-ssr.js
@@ -1,0 +1,25 @@
+
+/* this is a hack to fix `gatsby-plugin-sass` from including the
+  css in every single file (which is > 120k lines).
+  see: https://github.com/gatsbyjs/gatsby/issues/1526
+  `ssr` means server-side rendering.
+  */
+export const onPreRenderHTML = ({getHeadComponents}) => {
+  if (process.env.NODE_ENV !== 'production') {
+    return;
+  }
+
+  getHeadComponents().forEach((el) => {
+    // Remove inline css. https://github.com/gatsbyjs/gatsby/issues/1526
+    if (el.type === 'style') {
+      el.type = 'link';
+      el.props['href'] = el.props['data-href'];
+      el.props['rel'] = 'stylesheet';
+      el.props['type'] = 'text/css';
+
+      delete el.props['data-href'];
+      delete el.props['dangerouslySetInnerHTML'];
+      delete el.props['children'];
+    }
+  });
+};


### PR DESCRIPTION
Fix for issue #366

Created a gatsby-ssr.js to manually remove the css styles embedded in the pages.

SSR means "server side rendering". This fix is from a long github discussion about how broken including all css inline in the file is. 

The patch came from here: https://github.com/gatsbyjs/gatsby/issues/1526#issuecomment-433347822 

But honestly, I can't believe there is no flag to control this behavior and the issue was marked "Closed" by the Gatsby folks the way it works now. Especially since newer [CSP guidelines](https://content-security-policy.com/unsafe-inline/) say all css should be in a separate file.

The outputted file size for main `index.html`

```
Before:   462,099 bytes
After:      3,191 bytes
```
This is for _every single statically generated page_.

I tested locally but we should watch for production build issues.
