### PR TITLE
 Zoom button styling does not match spec

### DIFF
--- a/client/src/components/territoryFocusControl.module.scss
+++ b/client/src/components/territoryFocusControl.module.scss
@@ -1,6 +1,6 @@
 .territoryFocusButton {
-  width: 40px;
-  height: 40px;
+  width: 2.5em;
+  height: 2.5em;
   border-width: 1px 2px;
   border-color: #000000;
   border-style: solid;
@@ -16,7 +16,7 @@
   flex-direction: column;
   text-align: center;
   font-size: 16px;
-  line-height: 40px;
+  line-height: 1.75em;
   position: absolute;
   left: 20px;
   top: 300px;

--- a/client/src/styles/global.scss
+++ b/client/src/styles/global.scss
@@ -211,15 +211,50 @@ $primary-color: #112f4e;
 }
 
 // Because we're using react-map-gl, you need to use
-// the mapboxgl- class name variables
+// the mapboxgl- class name variables.
+// Maplibre has its own classnames with a maplibre prefix,
+// but it after 1.14.0 it optionally still allows for the mapbox-gl prefix
 
-.mapboxgl-ctrl-group button {
-  height: 40px;
-  width: 40px;
-  box-sizing: border-box;
-  border-width: 2px;
-  border-color: #000000;
-  border-style: solid;
-  background-color: #ffffff;
-  font-size: 24px;
+// Below properties override mb defaults
+.mapboxgl-ctrl-group:not(:empty) {
+  box-shadow: none;
+}
+
+@media (-ms-high-contrast: active) {
+  .mapboxgl-ctrl-group:not(:empty) {
+    box-shadow: none;
+  }
+}
+
+.mapboxgl-ctrl-group {
+  border-radius: 0px;
+}
+
+.mapboxgl-ctrl {
+  button + button {
+    border-top: 1px;
+  }
+
+  button {
+    border-radius: 0px;
+    height: 1.66em;
+    width: 1.66em;
+    box-sizing: border-box;
+    background-color: #ffffff;
+    border-width: 2px;
+    border-color: #000000;
+    border-style: solid;
+    font-size: 1.5em;
+  }
+  button.mapboxgl-ctrl-zoom-in {
+    .mapboxgl-ctrl-icon {
+      background-image: url("../../node_modules/uswds/dist/img/usa-icons/add.svg");
+    }
+  }
+
+  button.mapboxgl-ctrl-zoom-out {
+    .mapboxgl-ctrl-icon {
+      background-image: url("../../node_modules/uswds/dist/img/usa-icons/remove.svg");
+    }
+  }
 }

--- a/client/src/styles/global.scss
+++ b/client/src/styles/global.scss
@@ -245,7 +245,15 @@ $primary-color: #112f4e;
     border-color: #000000;
     border-style: solid;
     font-size: 1.5em;
+
+    // It seems necessary to set an explicit size for one of the dimensions
+    // in order for this icon to be rendered correctly by gatsby build
+    // see more here: https://thatemil.com/blog/2014/04/06/intrinsic-sizing-of-svg-in-responsive-web-design/
+    .mapboxgl-ctrl-icon {
+      height: 1em;
+    }
   }
+
   button.mapboxgl-ctrl-zoom-in {
     .mapboxgl-ctrl-icon {
       background-image: url("../../node_modules/uswds/dist/img/usa-icons/add.svg");


### PR DESCRIPTION
Fixes #320, Zoom button styling does not match spec

Our buttons had a ghost shadow, because of the legacy of inherited styles. Need to reference [mapbox's css](https://github.com/mapbox/mapbox-gl-js/blob/main/src/css/mapbox-gl.css) to know how and what to override. Converted a few px's to ems along the way!