### PR TITLE
Merges to main don't get posted to main && it should be clearer how branches are deployed

### DIFF
--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -6,12 +6,11 @@
 
 name: GH Pages deploy
 on:
-  push:
+  pull_request:
+    types: [ closed, opened ]
     branches: [main]
     paths:
       - 'client/**/*'
-  pull_request:
-    branches: [main]
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -30,7 +29,7 @@ jobs:
       # If this is just a PR branch, put content in a hash directory. Otherwise, put it in "main"
       # This variable is used by gatsby-config.js to set a prefixPath
       - name: Set DESTINATION_FOLDER for main
-        if: github.event.pull_request.merged == true
+        if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
         run: |
           echo "DESTINATION_FOLDER=main" >> $GITHUB_ENV
       - name: Set DESTINATION_FOLDER for branch
@@ -72,7 +71,7 @@ jobs:
           path: ./public
       # If this is just a PR branch, put content in a hash directory. Otherwise, put it in "main"
       - name: Set DESTINATION_FOLDER for main
-        if: github.event.pull_request.merged == true
+        if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
         run: |
           echo "DESTINATION_FOLDER=main" >> $GITHUB_ENV
       - name: Set DESTINATION_FOLDER for branch
@@ -82,7 +81,6 @@ jobs:
       - name: Deploy to Github Pages
         uses: JamesIves/github-pages-deploy-action@4.1.0
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: gh-pages # The branch the action should deploy to.
           FOLDER: public # The folder the action should deploy.
           TARGET-FOLDER: ${{env.DESTINATION_FOLDER}} # If we're on a PR branch, merge to PR folder
@@ -95,3 +93,18 @@ jobs:
           aws-region: us-east-1
       - name: Deploy to Geoplatform AWS
         run: aws s3 sync ./public/ s3://usds-geoplatform-justice40-website/justice40-tool/${{env.DESTINATION_FOLDER}} --delete
+      - name: Update PR with deployed URL
+        uses: mshick/add-pr-comment@v1
+        if: github.event_name == 'pull_request' && github.event.action == 'opened' # Only comment if the PR has been opened
+        with:
+          message: |
+            **🚢 PR Deployed! 🚢**
+            Find it here: https://d2zjid6n5ja2pt.cloudfront.net/justice40-tool/${{env.DESTINATION_FOLDER}}/en/cejst/ !
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token-user-login: 'github-actions[bot]' # The user.login for temporary GitHub tokens
+          allow-repeats: false # This is the default
+      - name: Printing deployment URLs
+        run: |
+          echo "Github pages: https://usds.github.io/justice40-tool/$DESTINATION_FOLDER/en
+          echo "Standard S3 bucket version (http only) : http://usds-geoplatform-justice40-website.s3-website-us-east-1.amazonaws.com/justice40-tool/$DESTINATION_FOLDER/en
+          ehoc "Cloudfront https: https://d2zjid6n5ja2pt.cloudfront.net/justice40-tool/$DESTINATION_FOLDER/en"

--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -11,6 +11,10 @@ on:
     branches: [main]
     paths:
       - 'client/**/*'
+  push:
+    branches:
+      - '*' # Run on all updates to PR branches
+      - '!main' # Do not run on pushes to main
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -95,7 +99,7 @@ jobs:
         run: aws s3 sync ./public/ s3://usds-geoplatform-justice40-website/justice40-tool/${{env.DESTINATION_FOLDER}} --delete
       - name: Update PR with deployed URL
         uses: mshick/add-pr-comment@v1
-        if: github.event_name == 'pull_request' && github.event.action == 'opened' # Only comment if the PR has been opened
+        if: github.event_name == 'pull_request' && github.event.action == 'opened' || github.event_name == 'push' # Only comment if the PR has been opened or a push has updated it
         with:
           message: |
             **🚢 PR Deployed! 🚢**
@@ -105,6 +109,6 @@ jobs:
           allow-repeats: false # This is the default
       - name: Printing deployment URLs
         run: |
-          echo "Github pages: https://usds.github.io/justice40-tool/$DESTINATION_FOLDER/en
-          echo "Standard S3 bucket version (http only) : http://usds-geoplatform-justice40-website.s3-website-us-east-1.amazonaws.com/justice40-tool/$DESTINATION_FOLDER/en
-          ehoc "Cloudfront https: https://d2zjid6n5ja2pt.cloudfront.net/justice40-tool/$DESTINATION_FOLDER/en"
+          echo "Github pages: https://usds.github.io/justice40-tool/$DESTINATION_FOLDER/en"
+          echo "Standard S3 bucket version (http only) : http://usds-geoplatform-justice40-website.s3-website-us-east-1.amazonaws.com/justice40-tool/$DESTINATION_FOLDER/en"
+          echo "Cloudfront https: https://d2zjid6n5ja2pt.cloudfront.net/justice40-tool/$DESTINATION_FOLDER/en"


### PR DESCRIPTION
fixes #319 - merges to main still don't get posted to /main , and #362 It should be clearer how branches are deployed.

Specifically:
* Moves to using `pull_request` instead of `push` -- this is actually the correct event, as we want these flows to fire when opening and closing pull requests, not simply pushing. We can't push to master directly anyhow.
* Also imposes the restriction that if the PR is closed, and merged, then we should update the `main` URL; otherwise, we should use the hash. Both of these need to be true; we could theoretically close without merging or merge without closing. 
* Only comment with the deployment URL when the PR is opened - when it has been closed, all PRs will go to `/main`. 
* Bot now adds comment to the PR itself with the URL of the preferred deployment
* Job now echoes the full set of URLs to the console when running the flow. 

tl;dr - we were using the wrong event and trigger; fixing this made it so we're setting the right variables to the right values and running at the right time.

(Interestingly because this fix targets `./client`, it won't fire for this change itself, but I have confirmed this fix does indeed work with a local repository.