### PR TITLE
Removes relative python imports

### DIFF
--- a/data/data-pipeline/data_pipeline/application.py
+++ b/data/data-pipeline/data_pipeline/application.py
@@ -1,10 +1,13 @@
 import click
 
-from .config import settings
-from .etl.runner import etl_runner, score_generate, score_geo
-from .etl.sources.census.etl_utils import reset_data_directories as census_reset
-from .tile.generate import generate_tiles
-from .utils import (
+from data_pipeline.config import settings
+from data_pipeline.etl.runner import etl_runner, score_generate, score_geo
+from data_pipeline.etl.sources.census.etl import download_census_csvs
+from data_pipeline.etl.sources.census.etl_utils import (
+    reset_data_directories as census_reset,
+)
+from data_pipeline.tile.generate import generate_tiles
+from data_pipeline.utils import (
     data_folder_cleanup,
     get_module_logger,
     score_folder_cleanup,

--- a/data/data-pipeline/data_pipeline/etl/sources/census/etl.py
+++ b/data/data-pipeline/data_pipeline/etl/sources/census/etl.py
@@ -8,7 +8,7 @@ import geopandas as gpd
 from data_pipeline.etl.base import ExtractTransformLoad
 from data_pipeline.utils import get_module_logger, unzip_file_from_url
 
-from .etl_utils import get_state_fips_codes
+from data_pipeline.etl.sources.census.etl_utils import get_state_fips_codes
 
 logger = get_module_logger(__name__)
 

--- a/data/data-pipeline/data_pipeline/utils.py
+++ b/data/data-pipeline/data_pipeline/utils.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import requests
 import urllib3
 
-from .config import settings
+from data_pipeline.config import settings
 
 
 def get_module_logger(module_name: str) -> logging.Logger:
@@ -97,7 +97,10 @@ def remove_all_dirs_from_dir(dir_path: Path) -> None:
 
 
 def unzip_file_from_url(
-    file_url: str, download_path: Path, unzipped_file_path: Path, verify: bool = False,
+    file_url: str,
+    download_path: Path,
+    unzipped_file_path: Path,
+    verify: bool = False,
 ) -> None:
     """Downloads a zip file from a remote URL location and unzips it in a specific directory, removing the temporary file after
 


### PR DESCRIPTION
Moving from relative imports to absolute to enable `poetry run python …data-pipeline/application.py [command]`. Relative imports do not work if running the file directly. Still preferred to run `poetry run download_census`, which should always work, but we should support this alternative way of calling it also