### PR TITLE
Initial refactor for Score ETL

### DIFF
--- a/data/data-pipeline/README.md
+++ b/data/data-pipeline/README.md
@@ -96,7 +96,7 @@ TODO add mermaid diagram
 3. Each ETL script will extract the data from its original source, then format the data into `.csv` files that get stored in the relevant folder in `data_pipeline/data/dataset/`. For example, HUD Housing data is stored in `data_pipeline/data/dataset/hud_housing/usa.csv`
 
 _**NOTE:** You have the option to pass the name of a specific data source to the `etl-run` command using the `-d` flag, which will limit the execution of the ETL process to that specific data source._
-_For example: `poetry run etl -- -d ejscreen` would only run the ETL process for EJSCREEN data._
+_For example: `poetry run etl -d ejscreen` would only run the ETL process for EJSCREEN data._
 
 #### Step 3: Calculate the Justice40 score experiments
 

--- a/data/data-pipeline/data_pipeline/etl/score/etl_score.py
+++ b/data/data-pipeline/data_pipeline/etl/score/etl_score.py
@@ -404,6 +404,7 @@ class ScoreETL(ExtractTransformLoad):
                 )
         return df
 
+    # TODO Make variables and constants clearer (meaning and type)
     def _add_score_f(self, df: pd.DataFrame) -> pd.DataFrame:
         logger.info("Adding Score F")
         ami_and_high_school_field_name = "Low AMI, Low HS graduation"
@@ -475,6 +476,7 @@ class ScoreETL(ExtractTransformLoad):
         )
         return df
 
+    # TODO Move a lot of this to the ETL part of the pipeline
     def _prepare_initial_df(self, data_sets: list) -> pd.DataFrame:
         logger.info("Preparing initial dataframe")
 
@@ -502,9 +504,12 @@ class ScoreETL(ExtractTransformLoad):
             census_tract_df, on=self.GEOID_TRACT_FIELD_NAME
         )
 
+        # If GEOID10s are read as numbers instead of strings, the initial 0 is dropped, 
+        # and then we get too many CBG rows (one for 012345 and one for 12345).
         if len(census_block_group_df) > 220333:
             raise ValueError("Too many rows in the join.")
         
+        # TODO Refactor to no longer use the data_sets list and do all renaming in ETL step
         # Rename columns:
         renaming_dict = {
             data_set.input_field: data_set.renamed_field
@@ -521,6 +526,7 @@ class ScoreETL(ExtractTransformLoad):
         df = df[columns_to_keep]
 
         # Convert all columns to numeric.
+        # TODO do this at the same time as calculating percentiles in future refactor
         for data_set in data_sets:
             # Skip GEOID_FIELD_NAME, because it's a string.
             if data_set.renamed_field == self.GEOID_FIELD_NAME:

--- a/data/data-pipeline/data_pipeline/etl/sources/census_acs/etl.py
+++ b/data/data-pipeline/data_pipeline/etl/sources/census_acs/etl.py
@@ -21,11 +21,11 @@ class CensusACSETL(ExtractTransformLoad):
             "Linguistic isolation (total)"
         )
         self.LINGUISTIC_ISOLATION_FIELDS = [
-            "C16002_001E",
-            "C16002_004E",
-            "C16002_007E",
-            "C16002_010E",
-            "C16002_013E",
+            "C16002_001E", # Estimate!!Total
+            "C16002_004E", # Estimate!!Total!!Spanish!!Limited English speaking household
+            "C16002_007E", # Estimate!!Total!!Other Indo-European languages!!Limited English speaking household
+            "C16002_010E", # Estimate!!Total!!Asian and Pacific Island languages!!Limited English speaking household
+            "C16002_013E", # Estimate!!Total!!Other languages!!Limited English speaking household
         ]
         self.MEDIAN_INCOME_FIELD = "B19013_001E"
         self.MEDIAN_INCOME_FIELD_NAME = (

--- a/data/data-pipeline/data_pipeline/etl/sources/hud_housing/etl.py
+++ b/data/data-pipeline/data_pipeline/etl/sources/hud_housing/etl.py
@@ -272,6 +272,12 @@ class HudHousingETL(ExtractTransformLoad):
             - self.df[RENTER_OCCUPIED_NOT_COMPUTED_FIELDS].sum(axis=1)
         )
 
+
+        self.df["DENOM INCL NOT COMPUTED"] = (
+            self.df[OWNER_OCCUPIED_POPULATION_FIELD]
+            + self.df[RENTER_OCCUPIED_POPULATION_FIELD]
+        )
+
         # TODO: add small sample size checks
         self.df[self.HOUSING_BURDEN_FIELD_NAME] = self.df[
             self.HOUSING_BURDEN_NUMERATOR_FIELD_NAME
@@ -293,5 +299,6 @@ class HudHousingETL(ExtractTransformLoad):
                 self.HOUSING_BURDEN_NUMERATOR_FIELD_NAME,
                 self.HOUSING_BURDEN_DENOMINATOR_FIELD_NAME,
                 self.HOUSING_BURDEN_FIELD_NAME,
+                "DENOM INCL NOT COMPUTED",
             ]
         ].to_csv(path_or_buf=self.OUTPUT_PATH / "usa.csv", index=False)


### PR DESCRIPTION
This begins the refactor for #326. So far it keeps everything in the etl_score.py file but ssplits things into functions/methods so that they will be easier to pull out into classes later. 

I tested this as I went by having a separate git-tracked folder containing the contents of `data/score/csv/full` (one of the outputs of the score etl) originally creeated from the `main` branch. Then I would move newly generated contents from this branch to that folder to replace the original, and then do `git status` to see if anything had changed. Nothing showed a having changed.