### PR TITLE
Update to score G from score D

### DIFF
--- a/client/src/data/constants.tsx
+++ b/client/src/data/constants.tsx
@@ -26,8 +26,8 @@ export const FEATURE_TILE_LOW_ZOOM_URL = featureURLForTilesetName('low');
 export const PERFORMANCE_MARKER_MAP_IDLE = 'MAP_IDLE';
 
 // Properties
-export const SCORE_PROPERTY_HIGH = 'Score D (percentile)';
-export const SCORE_PROPERTY_LOW = 'D_SCORE';
+export const SCORE_PROPERTY_HIGH = 'Score G (percentile)';
+export const SCORE_PROPERTY_LOW = 'G_SCORE';
 export const GEOID_PROPERTY = 'GEOID10';
 export const HIGH_SCORE_SOURCE_NAME = 'score-high';
 export const HIGH_SCORE_LAYER_NAME = 'score-high-layer';

--- a/client/src/data/constants.tsx
+++ b/client/src/data/constants.tsx
@@ -26,7 +26,7 @@ export const FEATURE_TILE_LOW_ZOOM_URL = featureURLForTilesetName('low');
 export const PERFORMANCE_MARKER_MAP_IDLE = 'MAP_IDLE';
 
 // Properties
-export const SCORE_PROPERTY_HIGH = 'Score G (percentile)';
+export const SCORE_PROPERTY_HIGH = 'Score G';
 export const SCORE_PROPERTY_LOW = 'G_SCORE';
 export const GEOID_PROPERTY = 'GEOID10';
 export const HIGH_SCORE_SOURCE_NAME = 'score-high';


### PR DESCRIPTION
In order for this to work, the PBF files for both the high and low zoom tiles will require the Score G key. This can be validated by running the [following](https://github.com/usds/justice40-tool/blob/main/client/VIEW_MAP_DATA.md#decoding-a-pbf-file) on the high and low zoom tiles.

TL;DR - an example of a low zoom tile (the z value in the url is 3):

```
curl https://d3jqyw10j8e7p9.cloudfront.net/data-pipeline/data/score/tiles/low/3/1/3.pbf -o d3_313.pbf

tippecanoe-decode d3_313.pbf 3 1 3 | jq
```

The output of tippecanoe-decode should have Score G key in the payload.

The same should happen with a high zoom tile.

