### PR TITLE
Add action for ping test and alert to Slack

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,33 @@
+# .github/workflows/ping-test.yml
+name: Trigger Run of site ping test
+on:
+  # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions
+  schedule:
+    # Run every hour
+    - cron: '0 * * * *'
+  # https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: 'Log level'     
+        required: true
+        default: 'warning'
+      tags:
+        description: 'Ping test'  
+jobs:
+  sitePingCheck:
+    name: Slack Notification
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    # https://github.com/marketplace/actions/ping-my-site
+    - uses: Leocardoso94/is-my-site-up@v1.2
+      with:
+        site: "https://d2zjid6n5ja2pt.cloudfront.net/justice40-tool/main/en/"
+    # https://www.ravsam.in/blog/send-slack-notification-when-github-actions-fails/
+    - uses: ravsamhq/notify-slack-action@v1
+      if: always()
+      with:
+        status: ${{ job.status }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,8 +3,8 @@ name: Trigger Run of site ping test
 on:
   # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions
   schedule:
-    # Run every hour
-    - cron: '0 * * * *'
+    # Run every five minutes
+    - cron: '*/5 * * * *'
   # https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/
   workflow_dispatch:
     inputs:
@@ -30,4 +30,4 @@ jobs:
       with:
         status: ${{ job.status }}
       env:
-        SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
+        SLACK_WEBHOOK_URL: ${{ secrets.J40_TOOL_MONITORING_SLACK_ALERTS }}


### PR DESCRIPTION
Based on @sverchdotgov 's https://github.com/sverchdotgov/github-actions-experiments/blob/master/.github/workflows/scheduled-email.yml

This is set to run every hour. We can modify as needed. It is also using our cloudfront URL and we'll need to change this to our new URL once we have it.