### PR TITLE
Update site with latest download file date + size

### DIFF
--- a/client/src/data/copy/methodology.tsx
+++ b/client/src/data/copy/methodology.tsx
@@ -23,8 +23,8 @@ export const PAGE = defineMessages({
 
 
 // Download Package
-export const DOWNLOAD_FILE_SIZE = '143MB';
-export const DOWNLOAD_LAST_UPDATED = '09/20/21';
+export const DOWNLOAD_FILE_SIZE = '111MB';
+export const DOWNLOAD_LAST_UPDATED = '10/01/21';
 export const VERSION_NUMBER = '0.1';
 
 export const DOWNLOAD_ZIP_URL = [

--- a/client/src/pages/__snapshots__/methodology.test.tsx.snap
+++ b/client/src/pages/__snapshots__/methodology.test.tsx.snap
@@ -313,12 +313,12 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
               <div>
                 <div>
                   <div>
-                    Draft communities list v0.1 (143MB)
+                    Draft communities list v0.1 (111MB)
                   </div>
                   <div>
                     The package includes draft v0.1  of the list of communities of focus (.csv and .xlsx)  and information about how to use the list (.pdf). 
                     <span>
-                      Last updated: 09/20/21 
+                      Last updated: 10/01/21 
                     </span>
                   </div>
                   <div>


### PR DESCRIPTION
I re-generated the download files today as part of #628 so needed to update the website to match.