### PR TITLE
Issue 932 fix too many tracts in ACS join

### DIFF
--- a/data/data-pipeline/data_pipeline/etl/sources/census_acs/etl.py
+++ b/data/data-pipeline/data_pipeline/etl/sources/census_acs/etl.py
@@ -91,12 +91,12 @@ class CensusACSETL(ExtractTransformLoad):
                     + self.LINGUISTIC_ISOLATION_FIELDS
                     + self.POVERTY_FIELDS,
                 )
+                dfs.append(response)
             except ValueError:
                 logger.error(
                     f"Could not download data for state/territory with FIPS code {fips}"
                 )
 
-            dfs.append(response)
 
         self.df = pd.concat(dfs)
 


### PR DESCRIPTION
Because of where this sneaky little `append` was in the code, if a call to the Census API failed (as it does for places like Guam and Virgin Islands), then it still appends the most recent value of `response`, which in this case was the data for Wyoming and Puerto Rico, which got appended multiple times.