### PR TITLE
Silence dev only vulnerabilities

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/**"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-type: "production"


### PR DESCRIPTION
Showing obscure vulnerabilities that only exist in the dev setup creates
more noise and means that they just get ignored (because they are
probably low priority). Silencing them means when we get a vulnerable
dependency alert we know to pay attention to it.

Comes from https://github.com/dependabot/dependabot-core/issues/2521 and
https://github.com/hpcc-systems/Tombolo/commit/501bbef57817a9a46498095fdbd2e1e7a6ce62fa.