### PR TITLE
Issue 1049: Stop swallowing Census API errors

### DIFF
--- a/data/data-pipeline/data_pipeline/etl/sources/census_acs_2010/etl.py
+++ b/data/data-pipeline/data_pipeline/etl/sources/census_acs_2010/etl.py
@@ -50,7 +50,6 @@ class CensusACS2010ETL(ExtractTransformLoad):
         ]
 
         self.EMPLOYMENT_LESS_THAN_HS_IN_LABOR_FORCE = (
-            # TODO: FIX!!!!!!
             "B23006_005E"
             # Estimate!!Total!!Less than high school graduate!!In labor force!!Civilian
         )
@@ -115,7 +114,6 @@ class CensusACS2010ETL(ExtractTransformLoad):
             tract_output_field_name=self.GEOID_TRACT_FIELD_NAME,
             data_path_for_fips_codes=self.DATA_PATH,
             acs_type=self.ACS_TYPE,
-            raise_errors=False,
         )
 
     def transform(self) -> None:


### PR DESCRIPTION
#1049. I noticed we were swallowing errors that happen on every request from the island territories. But this meant that new, unexpected errors were also getting swallowed, and the rest of the pipeline would run unaware that the source data was corrupted. 

This skips the island areas where we know Census ACS will never give us data, and raises all other errors.