### PR TITLE
Add category header and updates from Living Copy

### DIFF
--- a/INSTALLATION-es.md
+++ b/INSTALLATION-es.md
@@ -25,7 +25,7 @@ Descargar desde [sitio web](https://git-scm.com/download/win)
 2. Valide la instalación escribiendo `brew -v` en la terminal y asegúrese de que se muestre un número de versión.
 
 ### Instalar Node usando NVM
-
+<!-- markdown-link-check-disable-next-line -->
 Esto funcionará tanto para MacOS como para Win10. Siga las instrucciones de este [enlace](https://medium.com/@nodesource/installing-node-js-tutorial-using-nvm-5c6ff5925dd8)
 
 ### Configuración de IDE

--- a/client/README.md
+++ b/client/README.md
@@ -19,6 +19,7 @@ This README contains the following content:
 
 #### Install Node using NVM 
 
+<!-- markdown-link-check-disable-next-line -->
 This will work for both MacOS and Win10. Follow instructions on this [link](https://medium.com/@nodesource/installing-node-js-tutorial-using-nvm-5c6ff5925dd8). Be sure to read through the whole doc to find the sections within each step relevant to you (e.g. if you're using Homebrew, when you get to Step 2 look for the section, "Install NVM with Homebrew").
 
 If you install NVM using Homebrew, make sure to read the output in terminal after you run `brew install nvm`. You will need to add a few lines to your ~/.bash_profile and perhaps complete a couple other tasks.
@@ -70,6 +71,7 @@ DATA_SOURCE env variable in the docker-compose.yml. See [environment variables](
 
 #### Troubleshooting docker
 
+<!-- markdown-link-check-disable-next-line -->
 - If an error is thrown about [running out of space](https://medium.com/@wlarch/no-space-left-on-device-when-using-docker-compose-why-c4a2c783c6f6) on device see this for ways to reclaim space.
 
 

--- a/client/src/components/AreaDetail/areaDetail.module.scss
+++ b/client/src/components/AreaDetail/areaDetail.module.scss
@@ -82,3 +82,21 @@ $sidePanelLabelFontColor: #171716;
     font-size: medium;
   }  
 }
+
+// The following class is used in the AccordionItems in the AreaDetail component.
+// The Accordion component (parent of AccordionItems) requires some CSS overrides.
+// Local styling is not allowing the override. 
+// The override is needed to push into the bounds of the Accordion component's styles.
+// To override this, in globals.scss, we set the this .categoryHeader's vertical alignment by
+// setting styles in:
+//    .usa-accordion__content > *:first-child
+// This first child of the accordion content is the category header:
+.categoryHeader {
+  display: flex;
+  justify-content: space-between;
+  text-transform: uppercase;
+  font-size: small;
+  @include u-bg('gray-cool-5');
+  @include u-padding-left(2.5);
+  @include u-padding-right(2);
+}

--- a/client/src/components/AreaDetail/areaDetail.module.scss.d.ts
+++ b/client/src/components/AreaDetail/areaDetail.module.scss.d.ts
@@ -11,6 +11,7 @@ declare namespace MapModuleScssNamespace {
     versionInfo: string;
     showThresholdExceed:string;
     hideThresholdExceed:string;
+    categoryHeader:string;
   }
 }
 

--- a/client/src/components/AreaDetail/index.tsx
+++ b/client/src/components/AreaDetail/index.tsx
@@ -18,11 +18,20 @@ interface IAreaDetailProps {
   properties: constants.J40Properties,
 }
 
+/**
+ * This interface is used as define the various fields for each indicator in the side panel
+ *  label: the indicator label or title
+ *  description: the description of the indicator used in the side panel
+ *  value: the number from the geoJSON tile
+ *  isDisadvagtaged: the flag from the geoJSON tile
+ *  isPercent: is the value a percent or percentile
+ *  */
 export interface indicatorInfo {
   label: string,
   description: string,
   value: number,
   isDisadvagtaged: boolean,
+  isPercent?: boolean,
 }
 
 const AreaDetail = ({properties}:IAreaDetailProps) => {
@@ -45,84 +54,84 @@ const AreaDetail = ({properties}:IAreaDetailProps) => {
     label: intl.formatMessage(EXPLORE_COPY.SIDE_PANEL_INDICATORS.EXP_AG_LOSS),
     description: intl.formatMessage(EXPLORE_COPY.SIDE_PANEL_INDICATOR_DESCRIPTION.EXP_AG_LOSS),
     value: properties[constants.EXP_AGRICULTURE_LOSS_PERCENTILE] ?
-    properties[constants.EXP_AGRICULTURE_LOSS_PERCENTILE] : null,
+      properties[constants.EXP_AGRICULTURE_LOSS_PERCENTILE] : null,
     isDisadvagtaged: properties[constants.IS_GTE_90_EXP_AGR_LOSS_AND_IS_LOW_INCOME] ?
-    properties[constants.IS_GTE_90_EXP_AGR_LOSS_AND_IS_LOW_INCOME] : null,
+      properties[constants.IS_GTE_90_EXP_AGR_LOSS_AND_IS_LOW_INCOME] : null,
   };
   const expBldLoss:indicatorInfo = {
     label: intl.formatMessage(EXPLORE_COPY.SIDE_PANEL_INDICATORS.EXP_BLD_LOSS),
     description: intl.formatMessage(EXPLORE_COPY.SIDE_PANEL_INDICATOR_DESCRIPTION.EXP_BLD_LOSS),
     value: properties[constants.EXP_BUILDING_LOSS_PERCENTILE] ?
-    properties[constants.EXP_BUILDING_LOSS_PERCENTILE] : null,
+      properties[constants.EXP_BUILDING_LOSS_PERCENTILE] : null,
     isDisadvagtaged: properties[constants.IS_GTE_90_EXP_BLD_LOSS_AND_IS_LOW_INCOME] ?
-    properties[constants.IS_GTE_90_EXP_BLD_LOSS_AND_IS_LOW_INCOME] : null,
+      properties[constants.IS_GTE_90_EXP_BLD_LOSS_AND_IS_LOW_INCOME] : null,
   };
   const expPopLoss:indicatorInfo = {
     label: intl.formatMessage(EXPLORE_COPY.SIDE_PANEL_INDICATORS.EXP_POP_LOSS),
     description: intl.formatMessage(EXPLORE_COPY.SIDE_PANEL_INDICATOR_DESCRIPTION.EXP_POP_LOSS),
     value: properties[constants.EXP_POPULATION_LOSS_PERCENTILE] ?
-    properties[constants.EXP_POPULATION_LOSS_PERCENTILE] : null,
+      properties[constants.EXP_POPULATION_LOSS_PERCENTILE] : null,
     isDisadvagtaged: properties[constants.IS_GTE_90_EXP_POP_LOSS_AND_IS_LOW_INCOME] ?
-    properties[constants.IS_GTE_90_EXP_POP_LOSS_AND_IS_LOW_INCOME] : null,
+      properties[constants.IS_GTE_90_EXP_POP_LOSS_AND_IS_LOW_INCOME] : null,
   };
   const lowInc:indicatorInfo = {
     label: intl.formatMessage(EXPLORE_COPY.SIDE_PANEL_INDICATORS.LOW_INCOME),
     description: intl.formatMessage(EXPLORE_COPY.SIDE_PANEL_INDICATOR_DESCRIPTION.LOW_INCOME),
     value: properties[constants.POVERTY_BELOW_200_PERCENTILE] ?
-    properties[constants.POVERTY_BELOW_200_PERCENTILE] : null,
+      properties[constants.POVERTY_BELOW_200_PERCENTILE] : null,
     isDisadvagtaged: properties[constants.IS_FEDERAL_POVERTY_LEVEL_200] ?
-    properties[constants.IS_FEDERAL_POVERTY_LEVEL_200] : null,
+      properties[constants.IS_FEDERAL_POVERTY_LEVEL_200] : null,
   };
 
   const energyBurden:indicatorInfo = {
     label: intl.formatMessage(EXPLORE_COPY.SIDE_PANEL_INDICATORS.ENERGY_BURDEN),
     description: intl.formatMessage(EXPLORE_COPY.SIDE_PANEL_INDICATOR_DESCRIPTION.ENERGY_BURDEN),
     value: properties[constants.ENERGY_PERCENTILE] ?
-    properties[constants.ENERGY_PERCENTILE] : null,
+      properties[constants.ENERGY_PERCENTILE] : null,
     isDisadvagtaged: properties[constants.IS_GTE_90_ENERGY_BURDEN_AND_IS_LOW_INCOME] ?
-    properties[constants.IS_GTE_90_ENERGY_BURDEN_AND_IS_LOW_INCOME] : null,
+      properties[constants.IS_GTE_90_ENERGY_BURDEN_AND_IS_LOW_INCOME] : null,
   };
   const pm25:indicatorInfo = {
     label: intl.formatMessage(EXPLORE_COPY.SIDE_PANEL_INDICATORS.PM_2_5),
     description: intl.formatMessage(EXPLORE_COPY.SIDE_PANEL_INDICATOR_DESCRIPTION.PM_2_5),
     value: properties[constants.PM25_PERCENTILE] ?
-    properties[constants.PM25_PERCENTILE] : null,
+      properties[constants.PM25_PERCENTILE] : null,
     isDisadvagtaged: properties[constants.IS_GTE_90_PM25_AND_IS_LOW_INCOME] ?
-    properties[constants.IS_GTE_90_PM25_AND_IS_LOW_INCOME] : null,
+      properties[constants.IS_GTE_90_PM25_AND_IS_LOW_INCOME] : null,
   };
 
   const dieselPartMatter:indicatorInfo = {
     label: intl.formatMessage(EXPLORE_COPY.SIDE_PANEL_INDICATORS.DIESEL_PARTICULATE_MATTER),
     description: intl.formatMessage(EXPLORE_COPY.SIDE_PANEL_INDICATOR_DESCRIPTION.DIESEL_PARTICULATE_MATTER),
     value: properties[constants.DIESEL_MATTER_PERCENTILE] ?
-    properties[constants.DIESEL_MATTER_PERCENTILE] : null,
+      properties[constants.DIESEL_MATTER_PERCENTILE] : null,
     isDisadvagtaged: properties[constants.IS_GTE_90_DIESEL_PM_AND_IS_LOW_INCOME] ?
-    properties[constants.IS_GTE_90_DIESEL_PM_AND_IS_LOW_INCOME] : null,
+      properties[constants.IS_GTE_90_DIESEL_PM_AND_IS_LOW_INCOME] : null,
   };
   const trafficVolume:indicatorInfo = {
     label: intl.formatMessage(EXPLORE_COPY.SIDE_PANEL_INDICATORS.TRAFFIC_VOLUME),
     description: intl.formatMessage(EXPLORE_COPY.SIDE_PANEL_INDICATOR_DESCRIPTION.TRAFFIC_VOLUME),
     value: properties[constants.TRAFFIC_PERCENTILE] ?
-    properties[constants.TRAFFIC_PERCENTILE] : null,
+      properties[constants.TRAFFIC_PERCENTILE] : null,
     isDisadvagtaged: properties[constants.IS_GTE_90_TRAFFIC_PROX_AND_IS_LOW_INCOME] ?
-    properties[constants.IS_GTE_90_TRAFFIC_PROX_AND_IS_LOW_INCOME] : null,
+      properties[constants.IS_GTE_90_TRAFFIC_PROX_AND_IS_LOW_INCOME] : null,
   };
 
   const houseBurden:indicatorInfo = {
     label: intl.formatMessage(EXPLORE_COPY.SIDE_PANEL_INDICATORS.HOUSE_BURDEN),
     description: intl.formatMessage(EXPLORE_COPY.SIDE_PANEL_INDICATOR_DESCRIPTION.HOUSE_BURDEN),
     value: properties[constants.HOUSING_BURDEN_PROPERTY_PERCENTILE] ?
-    properties[constants.HOUSING_BURDEN_PROPERTY_PERCENTILE] : null,
+      properties[constants.HOUSING_BURDEN_PROPERTY_PERCENTILE] : null,
     isDisadvagtaged: properties[constants.IS_GTE_90_HOUSE_BURDEN_AND_IS_LOW_INCOME] ?
-    properties[constants.IS_GTE_90_HOUSE_BURDEN_AND_IS_LOW_INCOME] : null,
+      properties[constants.IS_GTE_90_HOUSE_BURDEN_AND_IS_LOW_INCOME] : null,
   };
   const leadPaint:indicatorInfo = {
     label: intl.formatMessage(EXPLORE_COPY.SIDE_PANEL_INDICATORS.LEAD_PAINT),
     description: intl.formatMessage(EXPLORE_COPY.SIDE_PANEL_INDICATOR_DESCRIPTION.LEAD_PAINT),
     value: properties[constants.LEAD_PAINT_PERCENTILE] ?
-    properties[constants.LEAD_PAINT_PERCENTILE] : null,
+      properties[constants.LEAD_PAINT_PERCENTILE] : null,
     isDisadvagtaged: properties[constants.IS_GTE_90_LEAD_PAINT_AND_MEDIAN_HOME_VAL_AND_IS_LOW_INCOME] ?
-    properties[constants.IS_GTE_90_LEAD_PAINT_AND_MEDIAN_HOME_VAL_AND_IS_LOW_INCOME] : null,
+      properties[constants.IS_GTE_90_LEAD_PAINT_AND_MEDIAN_HOME_VAL_AND_IS_LOW_INCOME] : null,
   };
   // const medHomeVal:indicatorInfo = {
   //   label: intl.formatMessage(EXPLORE_COPY.SIDE_PANEL_INDICATORS.MED_HOME_VAL),
@@ -136,108 +145,109 @@ const AreaDetail = ({properties}:IAreaDetailProps) => {
     label: intl.formatMessage(EXPLORE_COPY.SIDE_PANEL_INDICATORS.PROX_HAZ),
     description: intl.formatMessage(EXPLORE_COPY.SIDE_PANEL_INDICATOR_DESCRIPTION.PROX_HAZ),
     value: properties[constants.PROXIMITY_TSDF_SITES_PERCENTILE] ?
-    properties[constants.PROXIMITY_TSDF_SITES_PERCENTILE] : null,
+      properties[constants.PROXIMITY_TSDF_SITES_PERCENTILE] : null,
     isDisadvagtaged: properties[constants.IS_GTE_90_HAZARD_WASTE_AND_IS_LOW_INCOME] ?
-    properties[constants.IS_GTE_90_HAZARD_WASTE_AND_IS_LOW_INCOME] : null,
+      properties[constants.IS_GTE_90_HAZARD_WASTE_AND_IS_LOW_INCOME] : null,
   };
   const proxNPL:indicatorInfo = {
     label: intl.formatMessage(EXPLORE_COPY.SIDE_PANEL_INDICATORS.PROX_NPL),
     description: intl.formatMessage(EXPLORE_COPY.SIDE_PANEL_INDICATOR_DESCRIPTION.PROX_NPL),
     value: properties[constants.PROXIMITY_NPL_SITES_PERCENTILE] ?
-    properties[constants.PROXIMITY_NPL_SITES_PERCENTILE] : null,
+      properties[constants.PROXIMITY_NPL_SITES_PERCENTILE] : null,
     isDisadvagtaged: properties[constants.IS_GTE_90_SUPERFUND_AND_IS_LOW_INCOME] ?
-    properties[constants.IS_GTE_90_SUPERFUND_AND_IS_LOW_INCOME] : null,
+      properties[constants.IS_GTE_90_SUPERFUND_AND_IS_LOW_INCOME] : null,
   };
   const proxRMP:indicatorInfo = {
     label: intl.formatMessage(EXPLORE_COPY.SIDE_PANEL_INDICATORS.PROX_RMP),
     description: intl.formatMessage(EXPLORE_COPY.SIDE_PANEL_INDICATOR_DESCRIPTION.PROX_RMP),
     value: properties[constants.PROXIMITY_RMP_SITES_PERCENTILE] ?
-    properties[constants.PROXIMITY_RMP_SITES_PERCENTILE] : null,
+      properties[constants.PROXIMITY_RMP_SITES_PERCENTILE] : null,
     isDisadvagtaged: properties[constants.IS_GTE_90_RMP_AND_IS_LOW_INCOME] ?
-    properties[constants.IS_GTE_90_RMP_AND_IS_LOW_INCOME] : null,
+      properties[constants.IS_GTE_90_RMP_AND_IS_LOW_INCOME] : null,
   };
 
   const wasteWater:indicatorInfo = {
     label: intl.formatMessage(EXPLORE_COPY.SIDE_PANEL_INDICATORS.WASTE_WATER),
     description: intl.formatMessage(EXPLORE_COPY.SIDE_PANEL_INDICATOR_DESCRIPTION.WASTE_WATER),
     value: properties[constants.WASTEWATER_PERCENTILE] ?
-    properties[constants.WASTEWATER_PERCENTILE] : null,
+      properties[constants.WASTEWATER_PERCENTILE] : null,
     isDisadvagtaged: properties[constants.IS_GTE_90_WASTEWATER_AND_IS_LOW_INCOME] ?
-    properties[constants.IS_GTE_90_WASTEWATER_AND_IS_LOW_INCOME] : null,
+      properties[constants.IS_GTE_90_WASTEWATER_AND_IS_LOW_INCOME] : null,
   };
 
   const asthma:indicatorInfo = {
     label: intl.formatMessage(EXPLORE_COPY.SIDE_PANEL_INDICATORS.ASTHMA),
     description: intl.formatMessage(EXPLORE_COPY.SIDE_PANEL_INDICATOR_DESCRIPTION.ASTHMA),
     value: properties[constants.ASTHMA_PERCENTILE] ?
-    properties[constants.ASTHMA_PERCENTILE] : null,
+      properties[constants.ASTHMA_PERCENTILE] : null,
     isDisadvagtaged: properties[constants.IS_GTE_90_ASTHMA_AND_IS_LOW_INCOME] ?
-    properties[constants.IS_GTE_90_ASTHMA_AND_IS_LOW_INCOME] : null,
+      properties[constants.IS_GTE_90_ASTHMA_AND_IS_LOW_INCOME] : null,
   };
   const diabetes:indicatorInfo = {
     label: intl.formatMessage(EXPLORE_COPY.SIDE_PANEL_INDICATORS.DIABETES),
     description: intl.formatMessage(EXPLORE_COPY.SIDE_PANEL_INDICATOR_DESCRIPTION.DIABETES),
     value: properties[constants.DIABETES_PERCENTILE] ?
-    properties[constants.DIABETES_PERCENTILE] : null,
+      properties[constants.DIABETES_PERCENTILE] : null,
     isDisadvagtaged: properties[constants.IS_GTE_90_DIABETES_AND_IS_LOW_INCOME] ?
-    properties[constants.IS_GTE_90_DIABETES_AND_IS_LOW_INCOME] : null,
+      properties[constants.IS_GTE_90_DIABETES_AND_IS_LOW_INCOME] : null,
   };
   const heartDisease:indicatorInfo = {
     label: intl.formatMessage(EXPLORE_COPY.SIDE_PANEL_INDICATORS.HEART_DISEASE),
     description: intl.formatMessage(EXPLORE_COPY.SIDE_PANEL_INDICATOR_DESCRIPTION.HEART_DISEASE),
     value: properties[constants.HEART_PERCENTILE] ?
-    properties[constants.HEART_PERCENTILE] : null,
+      properties[constants.HEART_PERCENTILE] : null,
     isDisadvagtaged: properties[constants.IS_GTE_90_HEART_DISEASE_AND_IS_LOW_INCOME] ?
-    properties[constants.IS_GTE_90_HEART_DISEASE_AND_IS_LOW_INCOME] : null,
+      properties[constants.IS_GTE_90_HEART_DISEASE_AND_IS_LOW_INCOME] : null,
   };
   const lifeExpect:indicatorInfo = {
     label: intl.formatMessage(EXPLORE_COPY.SIDE_PANEL_INDICATORS.LIFE_EXPECT),
     description: intl.formatMessage(EXPLORE_COPY.SIDE_PANEL_INDICATOR_DESCRIPTION.LOW_LIFE_EXPECT),
     value: properties[constants.LIFE_PERCENTILE] ?
-    properties[constants.LIFE_PERCENTILE] : null,
+      properties[constants.LIFE_PERCENTILE] : null,
     isDisadvagtaged: properties[constants.IS_GTE_90_LOW_LIFE_EXP_AND_IS_LOW_INCOME] ?
-    properties[constants.IS_GTE_90_LOW_LIFE_EXP_AND_IS_LOW_INCOME] : null,
+      properties[constants.IS_GTE_90_LOW_LIFE_EXP_AND_IS_LOW_INCOME] : null,
   };
 
   const lowMedInc:indicatorInfo = {
     label: intl.formatMessage(EXPLORE_COPY.SIDE_PANEL_INDICATORS.LOW_MED_INC),
     description: intl.formatMessage(EXPLORE_COPY.SIDE_PANEL_INDICATOR_DESCRIPTION.LOW_MED_INCOME),
     value: properties[constants.LOW_MEDIAN_INCOME_PERCENTILE] ?
-    properties[constants.LOW_MEDIAN_INCOME_PERCENTILE] : null,
+      properties[constants.LOW_MEDIAN_INCOME_PERCENTILE] : null,
     isDisadvagtaged: properties[constants.IS_GTE_90_LOW_MEDIAN_INCOME_AND_LOW_HIGH_SCHOOL_EDU] ?
-    properties[constants.IS_GTE_90_LOW_MEDIAN_INCOME_AND_LOW_HIGH_SCHOOL_EDU] : null,
+      properties[constants.IS_GTE_90_LOW_MEDIAN_INCOME_AND_LOW_HIGH_SCHOOL_EDU] : null,
   };
   const lingIso:indicatorInfo = {
     label: intl.formatMessage(EXPLORE_COPY.SIDE_PANEL_INDICATORS.LING_ISO),
     description: intl.formatMessage(EXPLORE_COPY.SIDE_PANEL_INDICATOR_DESCRIPTION.LING_ISO),
     value: properties[constants.LINGUISTIC_ISOLATION_PROPERTY_PERCENTILE] ?
-    properties[constants.LINGUISTIC_ISOLATION_PROPERTY_PERCENTILE] : null,
+      properties[constants.LINGUISTIC_ISOLATION_PROPERTY_PERCENTILE] : null,
     isDisadvagtaged: properties[constants.IS_GTE_90_LINGUISITIC_ISO_AND_IS_LOW_INCOME] ?
-    properties[constants.IS_GTE_90_LINGUISITIC_ISO_AND_IS_LOW_INCOME] : null,
+      properties[constants.IS_GTE_90_LINGUISITIC_ISO_AND_IS_LOW_INCOME] : null,
   };
   const unemploy:indicatorInfo = {
     label: intl.formatMessage(EXPLORE_COPY.SIDE_PANEL_INDICATORS.UNEMPLOY),
     description: intl.formatMessage(EXPLORE_COPY.SIDE_PANEL_INDICATOR_DESCRIPTION.UNEMPLOY),
     value: properties[constants.UNEMPLOYMENT_PROPERTY_PERCENTILE] ?
-    properties[constants.UNEMPLOYMENT_PROPERTY_PERCENTILE] : null,
+      properties[constants.UNEMPLOYMENT_PROPERTY_PERCENTILE] : null,
     isDisadvagtaged: properties[constants.IS_GTE_90_UNEMPLOYMENT_AND_LOW_HIGH_SCHOOL_EDU] ?
-    properties[constants.IS_GTE_90_UNEMPLOYMENT_AND_LOW_HIGH_SCHOOL_EDU] : null,
+      properties[constants.IS_GTE_90_UNEMPLOYMENT_AND_LOW_HIGH_SCHOOL_EDU] : null,
   };
   const poverty:indicatorInfo = {
     label: intl.formatMessage(EXPLORE_COPY.SIDE_PANEL_INDICATORS.POVERTY),
     description: intl.formatMessage(EXPLORE_COPY.SIDE_PANEL_INDICATOR_DESCRIPTION.POVERTY),
     value: properties[constants.POVERTY_PROPERTY_PERCENTILE] ?
-    properties[constants.POVERTY_PROPERTY_PERCENTILE] : null,
+      properties[constants.POVERTY_PROPERTY_PERCENTILE] : null,
     isDisadvagtaged: properties[constants.IS_GTE_90_BELOW_100_POVERTY_AND_LOW_HIGH_SCHOOL_EDU] ?
-    properties[constants.IS_GTE_90_BELOW_100_POVERTY_AND_LOW_HIGH_SCHOOL_EDU] : null,
+      properties[constants.IS_GTE_90_BELOW_100_POVERTY_AND_LOW_HIGH_SCHOOL_EDU] : null,
   };
   const highSchool:indicatorInfo = {
     label: intl.formatMessage(EXPLORE_COPY.SIDE_PANEL_INDICATORS.HIGH_SCL),
     description: intl.formatMessage(EXPLORE_COPY.SIDE_PANEL_INDICATOR_DESCRIPTION.HIGH_SKL),
     value: properties[constants.HIGH_SCHOOL_PROPERTY_PERCENTILE] ?
-    properties[constants.HIGH_SCHOOL_PROPERTY_PERCENTILE] : null,
+      properties[constants.HIGH_SCHOOL_PROPERTY_PERCENTILE] : null,
     isDisadvagtaged: properties[constants.IS_GTE_90_UNEMPLOYMENT_AND_LOW_HIGH_SCHOOL_EDU] ?
-    properties[constants.IS_GTE_90_UNEMPLOYMENT_AND_LOW_HIGH_SCHOOL_EDU] : null,
+      properties[constants.IS_GTE_90_UNEMPLOYMENT_AND_LOW_HIGH_SCHOOL_EDU] : null,
+    isPercent: true,
   };
 
   // Aggregate indicators based on categories
@@ -247,56 +257,56 @@ const AreaDetail = ({properties}:IAreaDetailProps) => {
       titleText: intl.formatMessage(EXPLORE_COPY.SIDE_PANEL_CATEGORY.CLIMATE),
       indicators: [expAgLoss, expBldLoss, expPopLoss, lowInc],
       isDisadvagtaged: properties[constants.IS_CLIMATE_FACTOR_DISADVANTAGED_L] ?
-      properties[constants.IS_CLIMATE_FACTOR_DISADVANTAGED_L] : null,
+        properties[constants.IS_CLIMATE_FACTOR_DISADVANTAGED_L] : null,
     },
     {
       id: 'clean-energy',
       titleText: intl.formatMessage(EXPLORE_COPY.SIDE_PANEL_CATEGORY.CLEAN_ENERGY),
       indicators: [energyBurden, pm25, lowInc],
       isDisadvagtaged: properties[constants.IS_ENERGY_FACTOR_DISADVANTAGED_L] ?
-    properties[constants.IS_ENERGY_FACTOR_DISADVANTAGED_L] : null,
+        properties[constants.IS_ENERGY_FACTOR_DISADVANTAGED_L] : null,
     },
     {
       id: 'clean-transport',
       titleText: intl.formatMessage(EXPLORE_COPY.SIDE_PANEL_CATEGORY.CLEAN_TRANSPORT),
       indicators: [dieselPartMatter, trafficVolume, lowInc],
       isDisadvagtaged: properties[constants.IS_TRANSPORT_FACTOR_DISADVANTAGED_L] ?
-    properties[constants.IS_TRANSPORT_FACTOR_DISADVANTAGED_L] : null,
+        properties[constants.IS_TRANSPORT_FACTOR_DISADVANTAGED_L] : null,
     },
     {
       id: 'sustain-house',
       titleText: intl.formatMessage(EXPLORE_COPY.SIDE_PANEL_CATEGORY.SUSTAIN_HOUSE),
       indicators: [houseBurden, leadPaint, lowInc],
       isDisadvagtaged: properties[constants.IS_HOUSING_FACTOR_DISADVANTAGED_L] ?
-    properties[constants.IS_HOUSING_FACTOR_DISADVANTAGED_L] : null,
+        properties[constants.IS_HOUSING_FACTOR_DISADVANTAGED_L] : null,
     },
     {
       id: 'leg-pollute',
       titleText: intl.formatMessage(EXPLORE_COPY.SIDE_PANEL_CATEGORY.LEG_POLLUTE),
       indicators: [proxHaz, proxNPL, proxRMP, lowInc],
       isDisadvagtaged: properties[constants.IS_POLLUTION_FACTOR_DISADVANTAGED_L] ?
-    properties[constants.IS_POLLUTION_FACTOR_DISADVANTAGED_L] : null,
+        properties[constants.IS_POLLUTION_FACTOR_DISADVANTAGED_L] : null,
     },
     {
       id: 'clean-water',
       titleText: intl.formatMessage(EXPLORE_COPY.SIDE_PANEL_CATEGORY.CLEAN_WATER),
       indicators: [wasteWater, lowInc],
       isDisadvagtaged: properties[constants.IS_WATER_FACTOR_DISADVANTAGED_L] ?
-    properties[constants.IS_WATER_FACTOR_DISADVANTAGED_L] : null,
+        properties[constants.IS_WATER_FACTOR_DISADVANTAGED_L] : null,
     },
     {
       id: 'health-burdens',
       titleText: intl.formatMessage(EXPLORE_COPY.SIDE_PANEL_CATEGORY.HEALTH_BURDEN),
       indicators: [asthma, diabetes, heartDisease, lifeExpect, lowInc],
       isDisadvagtaged: properties[constants.IS_HEALTH_FACTOR_DISADVANTAGED_L] ?
-    properties[constants.IS_HEALTH_FACTOR_DISADVANTAGED_L] : null,
+        properties[constants.IS_HEALTH_FACTOR_DISADVANTAGED_L] : null,
     },
     {
       id: 'work-dev',
       titleText: intl.formatMessage(EXPLORE_COPY.SIDE_PANEL_CATEGORY.WORK_DEV),
       indicators: [lowMedInc, lingIso, unemploy, poverty, highSchool],
       isDisadvagtaged: properties[constants.IS_WORKFORCE_FACTOR_DISADVANTAGED_L] ?
-    properties[constants.IS_WORKFORCE_FACTOR_DISADVANTAGED_L] : null,
+        properties[constants.IS_WORKFORCE_FACTOR_DISADVANTAGED_L] : null,
     },
   ];
 

--- a/client/src/components/AreaDetail/index.tsx
+++ b/client/src/components/AreaDetail/index.tsx
@@ -308,6 +308,13 @@ const AreaDetail = ({properties}:IAreaDetailProps) => {
     title: <Category name={category.titleText} isDisadvantaged={category.isDisadvagtaged}/>,
     content: (
       <>
+        {/* Category Header */}
+        <div className={styles.categoryHeader}>
+          <div>{intl.formatMessage(EXPLORE_COPY.SIDE_PANEL_CATEGORY.INDICATOR)}</div>
+          <div>{intl.formatMessage(EXPLORE_COPY.SIDE_PANEL_CATEGORY.PERCENTILE)}</div>
+        </div>
+
+        {/* Category Indicators */}
         {category.indicators.map((indicator:any, index:number) => {
           return <Indicator key={`ind${index}`} indicator={indicator}/>;
         })}

--- a/client/src/components/AreaDetail/tests/__snapshots__/areaDetail.test.tsx.snap
+++ b/client/src/components/AreaDetail/tests/__snapshots__/areaDetail.test.tsx.snap
@@ -886,15 +886,16 @@ exports[`rendering of the AreaDetail checks if various text fields are visible 1
               High school degree achievement rate
               <div>
                 
-      Percent of people ages 25 years or older whose education level is less than a high school diploma
+      Percent (not a percentile) of people ages 25 years or older whose education level is less than a 
+      high school diploma
     
               </div>
             </div>
             <div>
               N/A
-              <sup>
-                <span />
-              </sup>
+              <span>
+                %
+              </span>
             </div>
           </div>
         </li>

--- a/client/src/components/AreaDetail/tests/__snapshots__/areaDetail.test.tsx.snap
+++ b/client/src/components/AreaDetail/tests/__snapshots__/areaDetail.test.tsx.snap
@@ -87,6 +87,14 @@ exports[`rendering of the AreaDetail checks if various text fields are visible 1
         hidden=""
         id="climate-change"
       >
+        <div>
+          <div>
+            Indicator
+          </div>
+          <div>
+            Percentile (0-100)
+          </div>
+        </div>
         <li
           data-cy="indicatorBox"
         >
@@ -190,6 +198,14 @@ exports[`rendering of the AreaDetail checks if various text fields are visible 1
         hidden=""
         id="clean-energy"
       >
+        <div>
+          <div>
+            Indicator
+          </div>
+          <div>
+            Percentile (0-100)
+          </div>
+        </div>
         <li
           data-cy="indicatorBox"
         >
@@ -273,6 +289,14 @@ exports[`rendering of the AreaDetail checks if various text fields are visible 1
         hidden=""
         id="clean-transport"
       >
+        <div>
+          <div>
+            Indicator
+          </div>
+          <div>
+            Percentile (0-100)
+          </div>
+        </div>
         <li
           data-cy="indicatorBox"
         >
@@ -356,6 +380,14 @@ exports[`rendering of the AreaDetail checks if various text fields are visible 1
         hidden=""
         id="sustain-house"
       >
+        <div>
+          <div>
+            Indicator
+          </div>
+          <div>
+            Percentile (0-100)
+          </div>
+        </div>
         <li
           data-cy="indicatorBox"
         >
@@ -441,6 +473,14 @@ exports[`rendering of the AreaDetail checks if various text fields are visible 1
         hidden=""
         id="leg-pollute"
       >
+        <div>
+          <div>
+            Indicator
+          </div>
+          <div>
+            Percentile (0-100)
+          </div>
+        </div>
         <li
           data-cy="indicatorBox"
         >
@@ -542,6 +582,14 @@ exports[`rendering of the AreaDetail checks if various text fields are visible 1
         hidden=""
         id="clean-water"
       >
+        <div>
+          <div>
+            Indicator
+          </div>
+          <div>
+            Percentile (0-100)
+          </div>
+        </div>
         <li
           data-cy="indicatorBox"
         >
@@ -607,6 +655,14 @@ exports[`rendering of the AreaDetail checks if various text fields are visible 1
         hidden=""
         id="health-burdens"
       >
+        <div>
+          <div>
+            Indicator
+          </div>
+          <div>
+            Percentile (0-100)
+          </div>
+        </div>
         <li
           data-cy="indicatorBox"
         >
@@ -731,6 +787,14 @@ exports[`rendering of the AreaDetail checks if various text fields are visible 1
         hidden=""
         id="work-dev"
       >
+        <div>
+          <div>
+            Indicator
+          </div>
+          <div>
+            Percentile (0-100)
+          </div>
+        </div>
         <li
           data-cy="indicatorBox"
         >

--- a/client/src/components/BetaBanner/__snapshots__/BetaBanner.test.tsx.snap
+++ b/client/src/components/BetaBanner/__snapshots__/BetaBanner.test.tsx.snap
@@ -10,8 +10,8 @@ exports[`rendering of the BetaBanner checks if component renders 1`] = `
           This is a beta site. 
         </span>
         <span>
-          It is an early, in-progress version of the tool with limited datasets 
-    that will be continuously updated.
+          It is an early, in-progress version of the tool with limited datasets that will 
+    be regularly updated.
         </span>
       </div>
     </div>

--- a/client/src/components/Categories/__snapshots__/Categories.test.tsx.snap
+++ b/client/src/components/Categories/__snapshots__/Categories.test.tsx.snap
@@ -176,7 +176,7 @@ exports[`rendering of the Categories checks if component renders 1`] = `
           low median home value
         </a>
          is at or less than
-        90th percentile OR at or above the 10th percentile for the 
+        90th percentile OR at or above the 90th percentile for the 
         <a
           href="#house-burden"
         >

--- a/client/src/components/DatasetCard/index.tsx
+++ b/client/src/components/DatasetCard/index.tsx
@@ -25,9 +25,7 @@ const DatasetCard = ({datasetCardProps}:IDatasetCardProps) => {
           <span className={styles.datasetCardLabels}>
             {intl.formatMessage(METHODOLOGY_COPY.DATASET_CARD_LABELS.RESP_PARTY)}
           </span>
-          <a href={datasetCardProps.dataSourceURL} target={'_blank'} rel="noreferrer">
-            {datasetCardProps.respPartyLabel}
-          </a>
+          {datasetCardProps.responsibleParty}
         </li>
         <li className={styles.datasetCardListItem}>
           <span className={styles.datasetCardLabels}>

--- a/client/src/components/DatasetCard/tests/__snapshots__/datasetCard.test.tsx.snap
+++ b/client/src/components/DatasetCard/tests/__snapshots__/datasetCard.test.tsx.snap
@@ -10,9 +10,9 @@ exports[`rendering of indicator dataset card checks if component renders 1`] = `
     </h3>
     <div>
       
-    Percent of a block group's population in households where household income is at or below
-    200% of the federal poverty level.
-    
+        Percent of a census tract's population in households where household income is at or below
+        200% of the federal poverty level.
+      
     </div>
     <ul>
       <li>
@@ -24,7 +24,7 @@ exports[`rendering of indicator dataset card checks if component renders 1`] = `
           rel="noreferrer"
           target="_blank"
         >
-          Census's American Community Survey.
+          Census's American Community Survey
         </a>
       </li>
       <li>

--- a/client/src/components/DatasetContainer/tests/__snapshots__/datasetContainer.test.tsx.snap
+++ b/client/src/components/DatasetContainer/tests/__snapshots__/datasetContainer.test.tsx.snap
@@ -40,9 +40,9 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
               </h3>
               <div>
                 
-    Percent of a block group's population in households where household income is at or below
-    200% of the federal poverty level.
-    
+        Percent of a census tract's population in households where household income is at or below
+        200% of the federal poverty level.
+      
               </div>
               <ul>
                 <li>
@@ -54,7 +54,7 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                     rel="noreferrer"
                     target="_blank"
                   >
-                    Census's American Community Survey.
+                    Census's American Community Survey
                   </a>
                 </li>
                 <li>
@@ -79,12 +79,12 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
               </h3>
               <div>
                 
-      Percent of agriculture value at risk from losses due to natural hazards. Calculated by dividing 
-      the agriculture value at risk in a census tract by the total agriculture value in that census 
-      tract. Fourteen natural hazards that have some link to climate change include: avalanche, 
-      coastal flooding, cold wave, drought, hail, heat wave, hurricane, ice storm, landslide, 
-      riverine flooding, strong wind, tornado, wildfire, and winter weather.
-    
+        Percent of agriculture value at risk from losses due to natural hazards. Calculated by dividing 
+        the agriculture value at risk in a census tract by the total agriculture value in that census 
+        tract. Fourteen natural hazards that have some link to climate change include: avalanche, 
+        coastal flooding, cold wave, drought, hail, heat wave, hurricane, ice storm, landslide, 
+        riverine flooding, strong wind, tornado, wildfire, and winter weather.
+      
               </div>
               <ul>
                 <li>
@@ -121,12 +121,12 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
               </h3>
               <div>
                 
-      Percent of building value at risk from losses due to natural hazards. Calculated by dividing the 
-      building value at risk in a census tract by the total building value in that census tract. 
-      Fourteen natural hazards that have some link to climate change include: avalanche, coastal flooding, 
-      cold wave, drought, hail, heat wave, hurricane, ice storm, landslide, riverine flooding, strong 
-      wind, tornado, wildfire, and winter weather.
-    
+        Percent of building value at risk from losses due to natural hazards. Calculated by dividing the 
+        building value at risk in a census tract by the total building value in that census tract. 
+        Fourteen natural hazards that have some link to climate change include: avalanche, 
+        coastal flooding, cold wave, drought, hail, heat wave, hurricane, ice storm, landslide, 
+        riverine flooding, strong wind, tornado, wildfire, and winter weather.
+        
               </div>
               <ul>
                 <li>
@@ -163,19 +163,18 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
               </h3>
               <div>
                 
-      Rate relative to the population in fatalities and injuries due to natural hazards each year. 
-      Fourteen natural hazards that have some link to climate change include: avalanche, coastal 
-      flooding, cold wave, drought, hail, heat wave, hurricane, ice storm, landslide, riverine 
-      flooding, strong wind, tornado, wildfire, and winter weather.
-      Population loss is defined as the Spatial Hazard Events and Losses or National Centers 
-      for Environmental Information’s (NCEI) reported number of fatalities and injuries caused by the 
-      hazard occurrence. To combine fatalities and injuries for the computation of population loss value, 
-      an injury is counted as one-tenth (1/10) of a fatality. The NCEI Storm Events Database 
-      classifies injuries and fatalities as direct or indirect. Both direct and indirect injuries 
-      and fatalities are counted as population loss. This total number of injuries and fatalities 
-      is then divided by the population in the census tract to get a per-capita rate of population risk. 
-    
-    
+        Rate relative to the population in fatalities and injuries due to natural hazards each year. 
+        Fourteen natural hazards that have some link to climate change include: avalanche, coastal 
+        flooding, cold wave, drought, hail, heat wave, hurricane, ice storm, landslide, riverine 
+        flooding, strong wind, tornado, wildfire, and winter weather.
+        Population loss is defined as the Spatial Hazard Events and Losses or National Centers 
+        for Environmental Information’s (NCEI) reported number of fatalities and injuries caused by the 
+        hazard occurrence. To combine fatalities and injuries for the computation of population loss value, 
+        an injury is counted as one-tenth (1/10) of a fatality. The NCEI Storm Events Database 
+        classifies injuries and fatalities as direct or indirect. Both direct and indirect injuries 
+        and fatalities are counted as population loss. This total number of injuries and fatalities 
+        is then divided by the population in the census tract to get a per-capita rate of population risk.   
+      
               </div>
               <ul>
                 <li>
@@ -247,8 +246,9 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                 PM2.5 in the air
               </h3>
               <div>
-                Fine inhalable particles, with diameters that are generally
-    2.5 micrometers and smaller.
+                
+        Fine inhalable particles, with diameters that are generally 2.5 micrometers and smaller.
+      
               </div>
               <ul>
                 <li>
@@ -260,8 +260,11 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                     rel="noreferrer"
                     target="_blank"
                   >
-                    Environmental Protection Agency (EPA) Office of Air
-    and Radiation (OAR) fusion of model and monitor data as compiled by EPA's EJSCREEN
+                    
+          Environmental Protection Agency (EPA) Office of Air and Radiation (OAR) fusion of model and monitor 
+          data as compiled by EPA's EJSCREEN, sourced from EPA National Air Toxics Assessment (NATA), 2017 
+          U.S. Department of Transportation (DOT) traffic data
+        
                   </a>
                 </li>
                 <li>
@@ -285,7 +288,9 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                 Diesel particulate matter exposure
               </h3>
               <div>
-                Mixture of particles that is part of diesel exhaust in the air.
+                
+        Mixture of particles that is part of diesel exhaust in the air.
+      
               </div>
               <ul>
                 <li>
@@ -297,8 +302,10 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                     rel="noreferrer"
                     target="_blank"
                   >
-                    Environmental Protection Agency (EPA) National Air Toxics Assessment (NATA)
-    as compiled by EPA's EJSCREEN
+                    
+          Environmental Protection Agency (EPA) National Air Toxics Assessment (NATA)
+          as compiled by EPA's EJSCREEN        
+        
                   </a>
                 </li>
                 <li>
@@ -322,8 +329,10 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                 Traffic proximity and volume
               </h3>
               <div>
-                Count of vehicles (average annual daily traffic) at major roads
-    within 500 meters, divided by distance in meters (not km).
+                
+        Count of vehicles (average annual daily traffic) at major roads
+        within 500 meters, divided by distance in meters (not km).
+      
               </div>
               <ul>
                 <li>
@@ -335,7 +344,9 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                     rel="noreferrer"
                     target="_blank"
                   >
-                    Department of Transportation (DOT) traffic data as compiled by EPA's EJSCREEN
+                    
+          Department of Transportation (DOT) traffic data as compiled by EPA's EJSCREEN      
+        
                   </a>
                 </li>
                 <li>
@@ -360,9 +371,9 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
               </h3>
               <div>
                 
-      The percent of households in a census tract that are both earning less than 80% of HUD Area Median 
-      Family Income by county and are paying greater than 30% of their income to housing costs.    
-    
+        The percent of households in a census tract that are both earning less than 80% of HUD Area Median 
+        Family Income by county and are paying greater than 30% of their income to housing costs.    
+      
               </div>
               <ul>
                 <li>
@@ -374,8 +385,10 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                     rel="noreferrer"
                     target="_blank"
                   >
-                    Department of Housing & Urban Development’s
-    (HUD) Comprehensive Housing Affordability Strategy dataset
+                    
+          Department of Housing & Urban Development’s
+          (HUD) Comprehensive Housing Affordability Strategy dataset
+        
                   </a>
                 </li>
                 <li>
@@ -400,8 +413,9 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
               </h3>
               <div>
                 
-      Percent of housing units built pre-1960, used as an indicator of potential lead paint exposure in 
-      tracts with median home values less than 90th percentile    
+        Percent of housing units built pre-1960, used as an indicator of potential lead paint exposure in 
+        tracts with median home values less than 90th percentile
+      
               </div>
               <ul>
                 <li>
@@ -437,7 +451,9 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                 Low median home value
               </h3>
               <div>
-                Median home value of owner-occupied housing units in the census tract.
+                
+        Median home value of owner-occupied housing units in the census tract.
+       
               </div>
               <ul>
                 <li>
@@ -474,9 +490,9 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
               </h3>
               <div>
                 
-      Count of hazardous waste facilities (Treatment, Storage, and Disposal Facilities and Large
-      Quantity Generators) within 5 km (or nearest beyond 5 km), each divided by distance in kilometers.
-    
+        Count of hazardous waste facilities (Treatment, Storage, and Disposal Facilities and Large
+        Quantity Generators) within 5 km (or nearest beyond 5 km), each divided by distance in kilometers.
+      
               </div>
               <ul>
                 <li>
@@ -489,16 +505,16 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                     target="_blank"
                   >
                     
-      Environmental Protection Agency (EPA) Treatment Storage, and Disposal Facilities
-      (TSDF) data calculated from EPA RCRA info database as compiled by EPA’s EJSCREEN
-    
+          Environmental Protection Agency (EPA) Treatment Storage, and Disposal Facilities
+          (TSDF) data calculated from EPA RCRA info database as compiled by EPA’s EJSCREEN
+        
                   </a>
                 </li>
                 <li>
                   <span>
                     Date range: 
                   </span>
-                  2015-2020
+                  2020
                 </li>
                 <li>
                   <span>
@@ -516,8 +532,9 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
               </h3>
               <div>
                 
-    Count of proposed or listed NPL - also known as superfund - sites within 5 km (or nearest one
-      beyond 5 km), each divided by distance in kilometers.
+        Count of proposed or listed NPL - also known as superfund - sites within 5 km (or nearest one
+        beyond 5 km), each divided by distance in kilometers.      
+        
               </div>
               <ul>
                 <li>
@@ -529,7 +546,9 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                     rel="noreferrer"
                     target="_blank"
                   >
-                    Environmental Protection Agency (EPA) CERCLIS database as compiled by EPA’s EJSCREEN
+                    
+          Environmental Protection Agency (EPA) CERCLIS database as compiled by EPA’s EJSCREEN        
+        
                   </a>
                 </li>
                 <li>
@@ -554,8 +573,9 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
               </h3>
               <div>
                 
-    Count of RMP (potential chemical accident management plan) facilities within 5 km (or nearest
-      one beyond 5 km), each divided by distance in kilometers.
+        Count of RMP (potential chemical accident management plan) facilities within 5 km (or nearest
+        one beyond 5 km), each divided by distance in kilometers.
+      
               </div>
               <ul>
                 <li>
@@ -567,7 +587,9 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                     rel="noreferrer"
                     target="_blank"
                   >
-                    Environmental Protection Agency (EPA) RMP database as compiled by EPA’s EJSCREEN
+                    
+          Environmental Protection Agency (EPA) RMP database as compiled by EPA’s EJSCREEN        
+        
                   </a>
                 </li>
                 <li>
@@ -580,7 +602,7 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                   <span>
                     Used in: 
                   </span>
-                  Affordable and sustainable housing methodology
+                  Remediation of legacy pollution methodology
                 </li>
               </ul>
             </div>
@@ -591,8 +613,10 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                 Wastewater discharge
               </h3>
               <div>
-                Risk-Screening Environmental Indicators (RSEI) modeled Toxic Concentrations at 
-    stream segments within 500 meters, divided by distance in kilometers (km).
+                
+        Risk-Screening Environmental Indicators (RSEI) modeled Toxic Concentrations at 
+        stream segments within 500 meters, divided by distance in kilometers (km).
+      
               </div>
               <ul>
                 <li>
@@ -604,8 +628,10 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                     rel="noreferrer"
                     target="_blank"
                   >
-                    Environmental Protection Agency (EPA) Risk-Screening
-    Environmental Indicators (RSEI) Model as compiled by EPA's EJSCREEN
+                    
+          Environmental Protection Agency (EPA) Risk-Screening
+          Environmental Indicators (RSEI) Model as compiled by EPA's EJSCREEN        
+        
                   </a>
                 </li>
                 <li>
@@ -629,10 +655,11 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                 Asthma
               </h3>
               <div>
-                Weighted percent of people who answer “yes” both
-    to both of the following questions: “Have you ever been told by a doctor,
-    nurse, or other health professional that you have asthma?” and the question
-    “Do you still have asthma?”
+                
+        Weighted percent of people who answer “yes” to both of the following questions: “Have you ever 
+        been told by a doctor, nurse, or other health professional that you have asthma?” and the question
+        “Do you still have asthma?”
+      
               </div>
               <ul>
                 <li>
@@ -644,7 +671,9 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                     rel="noreferrer"
                     target="_blank"
                   >
-                    Centers for Disease Control and Prevention (CDC) PLACES
+                    
+          Centers for Disease Control and Prevention (CDC) PLACES        
+        
                   </a>
                 </li>
                 <li>
@@ -668,9 +697,11 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                 Diabetes
               </h3>
               <div>
-                Weighted percent of people ages 18 years and older who report having ever been
-    told by a doctor, nurse, or other health professionals that they have
-    diabetes other than diabetes during pregnancy.
+                
+        Weighted percent of people ages 18 years and older who report having ever been
+        told by a doctor, nurse, or other health professionals that they have
+        diabetes other than diabetes during pregnancy.
+      
               </div>
               <ul>
                 <li>
@@ -682,7 +713,9 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                     rel="noreferrer"
                     target="_blank"
                   >
-                    Centers for Disease Control and Prevention (CDC) PLACES
+                    
+          Centers for Disease Control and Prevention (CDC) PLACES        
+        
                   </a>
                 </li>
                 <li>
@@ -706,9 +739,11 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                 Heart disease
               </h3>
               <div>
-                Weighted percent of people ages 18 years and older who report ever having been told
-    by a doctor, nurse, or other health professionals that they had angina or
-    coronary heart disease.
+                
+        Weighted percent of people ages 18 years and older who report ever having been told
+        by a doctor, nurse, or other health professionals that they had angina or
+        coronary heart disease.
+      
               </div>
               <ul>
                 <li>
@@ -720,7 +755,9 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                     rel="noreferrer"
                     target="_blank"
                   >
-                    Centers for Disease Control and Prevention (CDC) PLACES
+                    
+          Centers for Disease Control and Prevention (CDC) PLACES        
+        
                   </a>
                 </li>
                 <li>
@@ -745,13 +782,22 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
               </h3>
               <div>
                 
-      Average number of years of life a person who has attained a given age can expect to live.
-      Note: Unlike most of the other datasets, high values of this indicator indicate low burdens. 
-      For percentile calculations, the percentile is calculated in reverse order, so that the tract with 
-      the highest median income relative to area median income (lowest burden on this measure) is at the 
-      0th percentile, and the tract with the lowest median income relative to area median income 
-      (highest burden on this measure) is at the 100th percentile.
-    
+        Average number of years of life a person who has attained a given age can expect to live.
+        
+                <p>
+                  <strong>
+                    Note:
+                  </strong>
+                  
+          Unlike most of the other datasets, high values of this indicator indicate low burdens. 
+          For percentile calculations, the percentile is calculated in reverse order, so that the tract with 
+          the highest median income relative to area median income (lowest burden on this measure) is at the 
+          0th percentile, and the tract with the lowest median income relative to area median income 
+          (highest burden on this measure) is at the 100th percentile.
+        
+                </p>
+                
+      
               </div>
               <ul>
                 <li>
@@ -763,7 +809,9 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                     rel="noreferrer"
                     target="_blank"
                   >
-                    CDC’s U.S. Small-area Life Expectancy Estimates Project (USALEEP)
+                    
+          CDC’s U.S. Small-area Life Expectancy Estimates Project (USALEEP)        
+        
                   </a>
                 </li>
                 <li>
@@ -787,7 +835,9 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                 Low median Income
               </h3>
               <div>
-                Median income of the census tract calculated as a percent of the area’s median income.
+                
+        Median income of the census tract calculated as a percent of the area’s median income.
+      
               </div>
               <ul>
                 <li>
@@ -824,8 +874,8 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
               </h3>
               <div>
                 
-      The percent of limited speaking households, which are households where no one over age 14 speaks English well.
-    
+        The percent of limited speaking households, which are households where no one over age 14 speaks English well.
+      
               </div>
               <ul>
                 <li>
@@ -861,7 +911,9 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                 Unemployment
               </h3>
               <div>
-                Number of unemployed people as a percentage of the civilian labor force
+                
+      Number of unemployed people as a percentage of the civilian labor force
+      
               </div>
               <ul>
                 <li>
@@ -897,7 +949,10 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                 Poverty
               </h3>
               <div>
-                Percent of a tract's population in households where the household income is at or below 100% of the federal poverty level.
+                
+        Percent of a tract's population in households where the household income is at or below 100% of 
+        the federal poverty level.
+      
               </div>
               <ul>
                 <li>
@@ -933,8 +988,10 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                 High school degree achievement rate
               </h3>
               <div>
-                Percent of people ages 25 years or older in a census tract whose
-    education level is less than a high school diploma.
+                
+        Percent (not percentile) of people ages 25 years or older in a census tract whose
+        education level is less than a high school diploma.
+      
               </div>
               <ul>
                 <li>

--- a/client/src/components/DatasetContainer/tests/__snapshots__/datasetContainer.test.tsx.snap
+++ b/client/src/components/DatasetContainer/tests/__snapshots__/datasetContainer.test.tsx.snap
@@ -602,7 +602,7 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                   <span>
                     Used in: 
                   </span>
-                  Remediation of legacy pollution methodology
+                  Reduction and remediation of legacy pollution methodology
                 </li>
               </ul>
             </div>
@@ -862,7 +862,7 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                   <span>
                     Used in: 
                   </span>
-                  Training and workforce development
+                  Training and workforce development methodology
                 </li>
               </ul>
             </div>
@@ -900,7 +900,7 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                   <span>
                     Used in: 
                   </span>
-                  Training and workforce development
+                  Training and workforce development methodology
                 </li>
               </ul>
             </div>
@@ -938,7 +938,7 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                   <span>
                     Used in: 
                   </span>
-                  Training and workforce development
+                  Training and workforce development methodology
                 </li>
               </ul>
             </div>
@@ -977,7 +977,7 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                   <span>
                     Used in: 
                   </span>
-                  Training and workforce development
+                  Training and workforce development methodology
                 </li>
               </ul>
             </div>
@@ -1016,7 +1016,7 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                   <span>
                     Used in: 
                   </span>
-                  Training and workforce development
+                  Training and workforce development methodology
                 </li>
               </ul>
             </div>

--- a/client/src/components/Indicator/Indicator.tsx
+++ b/client/src/components/Indicator/Indicator.tsx
@@ -43,9 +43,12 @@ const Indicator = ({indicator}:IIndicator) => {
         </div>
         <div className={styles.indicatorValue}>
           {readablePercentile(indicator.value)}
-          <sup className={styles.indicatorSuperscript}><span>
-            {getSuperscriptOrdinal(readablePercentile(indicator.value))}
-          </span></sup>
+          {indicator.isPercent ?
+            <span>{`%`}</span> :
+            <sup className={styles.indicatorSuperscript}>
+              <span>{getSuperscriptOrdinal(readablePercentile(indicator.value))}</span>
+            </sup>
+          }
         </div>
       </div>
     </li>

--- a/client/src/components/J40Header/__snapshots__/J40Header.test.tsx.snap
+++ b/client/src/components/J40Header/__snapshots__/J40Header.test.tsx.snap
@@ -150,8 +150,8 @@ exports[`rendering of the J40Header checks if component renders 1`] = `
             This is a beta site. 
           </span>
           <span>
-            It is an early, in-progress version of the tool with limited datasets 
-    that will be continuously updated.
+            It is an early, in-progress version of the tool with limited datasets that will 
+    be regularly updated.
           </span>
         </div>
       </div>

--- a/client/src/data/copy/common.tsx
+++ b/client/src/data/copy/common.tsx
@@ -9,8 +9,8 @@ export const BETA_BANNER = defineMessages({
   },
   INFO: {
     id: 'banner.beta.info',
-    defaultMessage: `It is an early, in-progress version of the tool with limited datasets 
-    that will be continuously updated.`,
+    defaultMessage: `It is an early, in-progress version of the tool with limited datasets that will 
+    be regularly updated.`,
     description: 'the main info of the beta banner',
   },
 });

--- a/client/src/data/copy/explore.tsx
+++ b/client/src/data/copy/explore.tsx
@@ -560,7 +560,8 @@ export const SIDE_PANEL_INDICATOR_DESCRIPTION = defineMessages({
   HIGH_SKL: {
     id: 'areaDetail.indicator.description.high.school',
     defaultMessage: `
-      Percent of people ages 25 years or older whose education level is less than a high school diploma
+      Percent (not a percentile) of people ages 25 years or older whose education level is less than a 
+      high school diploma
     `,
     description: 'Percent of people ages 25 years or older whose education level is less than a high school diploma',
   },
@@ -607,7 +608,7 @@ export const NOTE_ON_TERRITORIES = {
   PARA_1: <FormattedMessage
     id={'explore.page.note.on.territories.para.1'}
     defaultMessage={`
-      The data sources described on the {dataMethLink} are used to 
+      The data sources described on the {dataMethLink} page are used to 
       identify disadvantaged communities for all fifty states and the District of Columbia. However, not all 
       of these data sources are currently available for the U.S. territories. The Census ACS data from 
       2015-2019 was used to identify disadvantaged communities for Puerto Rico. This uses the same methodology 

--- a/client/src/data/copy/explore.tsx
+++ b/client/src/data/copy/explore.tsx
@@ -237,6 +237,16 @@ export const COMMUNITY = {
 };
 
 export const SIDE_PANEL_CATEGORY = defineMessages({
+  INDICATOR: {
+    id: 'areaDetail.category.header.indicator',
+    defaultMessage: 'Indicator',
+    description: 'header for each category',
+  },
+  PERCENTILE: {
+    id: 'areaDetail.category.header.percentile',
+    defaultMessage: 'Percentile (0-100)',
+    description: 'header for each category',
+  },
   CLIMATE: {
     id: 'areaDetail.indicator.title.climate',
     defaultMessage: 'Climate change',

--- a/client/src/data/copy/methodology.tsx
+++ b/client/src/data/copy/methodology.tsx
@@ -148,7 +148,20 @@ export const CATEGORY= {
 
 // Indicator Categories copy constants:
 export const CATEGORIES = {
+  ALL: {
+    METHODOLOGY:
+      <FormattedMessage
+        id= {'methodologies.all.used.in.text'}
+        defaultMessage= {`All methodologies except for training and workforce development`}
+        description= {'used in text for all methodologies'}
+      />,
+  },
   CLIMATE_CHANGE: {
+    METHODOLOGY: <FormattedMessage
+      id= {'indicator.categories.climate.change.methodology'}
+      defaultMessage= {`Climate change methodology`}
+      description= {'climate change methodology'}
+    />,
     TITLE: <FormattedMessage
       id={'indicator.categories.climate.change.title'}
       defaultMessage={'Climate change'}
@@ -187,6 +200,11 @@ export const CATEGORIES = {
     />,
   },
   CLEAN_ENERGY: {
+    METHODOLOGY: <FormattedMessage
+      id= {'indicator.categories.climate.change.methodology'}
+      defaultMessage= {`Clean energy and energy efficiency methodology`}
+      description= {`Clean energy and energy efficiency methodology`}
+    />,
     TITLE: <FormattedMessage
       id={'indicator.categories.clean.energy.title'}
       defaultMessage={'Clean energy and energy efficiency'}
@@ -224,6 +242,11 @@ export const CATEGORIES = {
     />,
   },
   CLEAN_TRANSPORT: {
+    METHODOLOGY: <FormattedMessage
+      id= {'indicator.categories.clean.transport.methodology'}
+      defaultMessage= {`Clean transportation methodology`}
+      description= {`Clean transportation methodology`}
+    />,
     TITLE: <FormattedMessage
       id={'indicator.categories.clean.transport.title'}
       defaultMessage={'Clean transportation'}
@@ -261,6 +284,11 @@ export const CATEGORIES = {
     />,
   },
   AFFORDABLE_HOUSING: {
+    METHODOLOGY: <FormattedMessage
+      id= {'indicator.categories.afford.housing.methodology'}
+      defaultMessage= {`Affordable and sustainable housing methodology`}
+      description= {`Affordable and sustainable housing methodology`}
+    />,
     TITLE: <FormattedMessage
       id={'indicator.categories.afford.house.title'}
       defaultMessage={'Affordable and sustainable housing'}
@@ -270,7 +298,7 @@ export const CATEGORIES = {
       id= {'indicator.categories.afford.house.if'}
       defaultMessage= {`
         {if} at or above 90th percentile for {lead} AND {medianHomeVal} is at or less than
-        90th percentile OR at or above the 10th percentile for the {houseBur}
+        90th percentile OR at or above the 90th percentile for the {houseBur}
       `}
       description= {'if portion of the formula'}
       values= {{
@@ -300,6 +328,16 @@ export const CATEGORIES = {
     />,
   },
   LEGACY_POLLUTION: {
+    METHODOLOGY: <FormattedMessage
+      id= {'indicator.categories.legacy.pollute.methodology'}
+      defaultMessage= {`Reduction and remediation of legacy pollution methodology`}
+      description= {`Reduction and remediation of legacy pollution methodology`}
+    />,
+    METHODOLOGY_REMEDIATION_ONLY: <FormattedMessage
+      id= {'indicator.categories.remediation.methodology'}
+      defaultMessage= {`Remediation of legacy pollution methodology`}
+      description= {`Remediation of legacy pollution methodology`}
+    />,
     TITLE: <FormattedMessage
       id={'indicator.categories.legacy.pollution.title'}
       defaultMessage={'Reduction and remediation of legacy pollution'}
@@ -338,6 +376,11 @@ export const CATEGORIES = {
     />,
   },
   CLEAN_WATER: {
+    METHODOLOGY: <FormattedMessage
+      id= {'indicator.categories.clean.water.methodology'}
+      defaultMessage= {`Critical clean water and waste infrastructure`}
+      description= {`Critical clean water and waste infrastructure`}
+    />,
     TITLE: <FormattedMessage
       id={'indicator.categories.clean.water.title'}
       defaultMessage={'Critical clean water and waste infrastructure'}
@@ -374,6 +417,11 @@ export const CATEGORIES = {
     />,
   },
   HEALTH_BURDENS: {
+    METHODOLOGY: <FormattedMessage
+      id= {'indicator.categories.health.burdens.methodology'}
+      defaultMessage= {`Health burdens methodology`}
+      description= {`Health burdens methodology`}
+    />,
     TITLE: <FormattedMessage
       id={'indicator.categories.health.burdens.title'}
       defaultMessage={'Health burdens'}
@@ -413,6 +461,11 @@ export const CATEGORIES = {
     />,
   },
   WORKFORCE_DEV: {
+    METHODOLOGY: <FormattedMessage
+      id= {'indicator.categories.workforce.dev.methodology'}
+      defaultMessage= {`Training and workforce development`}
+      description= {`Training and workforce development`}
+    />,
     TITLE: <FormattedMessage
       id={'indicator.categories.work.dev.title'}
       defaultMessage={'Training and workforce development'}
@@ -503,303 +556,592 @@ export const DATASET_CARD_LABELS = defineMessages({
   },
 });
 
+export const RESPONSIBLE_PARTIES = {
+  CENSUS_ACS: <FormattedMessage
+    id= {'category.resp.party.census.link'}
+    defaultMessage= {'{resPartyCensusLink}'}
+    description= {'responsible party link for Census ACS'}
+    values= {{
+      resPartyCensusLink:
+      <a href={`https://www.census.gov/programs-surveys/acs`} target={'_blank'} rel="noreferrer">
+        {`Census's American Community Survey`}
+      </a>,
+    }}
+  />,
+  FEMA: <FormattedMessage
+    id= {'category.resp.party.fema.link'}
+    defaultMessage= {`{resPartyFemaLink}`}
+    description= {'responsible party link for FEMA'}
+    values={{
+      resPartyFemaLink:
+      <a href={`https://hazards.fema.gov/nri/expected-annual-loss`} target={'_blank'} rel="noreferrer">
+        {`Federal Emergency Management Agency (FEMA)`}
+      </a>,
+    }}
+  />,
+  DOE: <FormattedMessage
+    id= {'category.resp.party.doe.link'}
+    defaultMessage= {`{resPartyDoeLink}`}
+    description= {'responsible party link for FEMA'}
+    values={{
+      resPartyDoeLink:
+      <a href={`https://www.energy.gov/eere/slsc/low-income-energy-affordability-data-lead-tool`}
+        target={'_blank'}
+        rel="noreferrer">
+        {`Department of Energy (DOE) LEAD Score`}
+      </a>,
+    }}
+  />,
+  EPA_OAR: <FormattedMessage
+    id= {'category.resp.party.epa.oar.link'}
+    defaultMessage= {`{resPartyEpaOarLink}`}
+    description= {'responsible party link for EPA OAR'}
+    values={{
+      resPartyEpaOarLink:
+      <a href={`https://www.epa.gov/ejscreen/technical-documentation-ejscreen`}
+        target={'_blank'}
+        rel="noreferrer">
+        {`
+          Environmental Protection Agency (EPA) Office of Air and Radiation (OAR) fusion of model and monitor 
+          data as compiled by EPA's EJSCREEN, sourced from EPA National Air Toxics Assessment (NATA), 2017 
+          U.S. Department of Transportation (DOT) traffic data
+        `}
+      </a>,
+    }}
+  />,
+  EPA_NATA: <FormattedMessage
+    id= {'category.resp.party.epa.nata.link'}
+    defaultMessage= {`{resPartyEpaOarLink}`}
+    description= {'responsible party link for EPA NATA'}
+    values={{
+      resPartyEpaOarLink:
+      <a href={`https://www.epa.gov/ejscreen/technical-documentation-ejscreen`}
+        target={'_blank'}
+        rel="noreferrer">
+        {`
+          Environmental Protection Agency (EPA) National Air Toxics Assessment (NATA)
+          as compiled by EPA's EJSCREEN        
+        `}
+      </a>,
+    }}
+  />,
+  DOT_EPA: <FormattedMessage
+    id= {'category.resp.party.dot.epa.link'}
+    defaultMessage= {`{resPartyDotEpaLink}`}
+    description= {'responsible party link for DOT EPA'}
+    values={{
+      resPartyDotEpaLink:
+      <a href={`https://www.epa.gov/ejscreen/technical-documentation-ejscreen`}
+        target={'_blank'}
+        rel="noreferrer">
+        {`
+          Department of Transportation (DOT) traffic data as compiled by EPA's EJSCREEN      
+        `}
+      </a>,
+    }}
+  />,
+  HUD: <FormattedMessage
+    id= {'category.resp.party.hud.link'}
+    defaultMessage= {`{resPartyHudLink}`}
+    description= {'responsible party link for HUD'}
+    values={{
+      resPartyHudLink:
+      <a href={`https://www.huduser.gov/portal/datasets/cp.html`}
+        target={'_blank'}
+        rel="noreferrer">
+        {`
+          Department of Housing & Urban Development’s
+          (HUD) Comprehensive Housing Affordability Strategy dataset
+        `}
+      </a>,
+    }}
+  />,
+  EPA_TSDF: <FormattedMessage
+    id= {'category.resp.party.epa.tsdf.link'}
+    defaultMessage= {`{resPartyEpaTsdfLink}`}
+    description= {'responsible party link for EPA TSDF'}
+    values={{
+      resPartyEpaTsdfLink:
+      <a href={`https://enviro.epa.gov/facts/rcrainfo/search.html`}
+        target={'_blank'}
+        rel="noreferrer">
+        {`
+          Environmental Protection Agency (EPA) Treatment Storage, and Disposal Facilities
+          (TSDF) data calculated from EPA RCRA info database as compiled by EPA’s EJSCREEN
+        `}
+      </a>,
+    }}
+  />,
+  EPA_CERCLIS: <FormattedMessage
+    id= {'category.resp.party.epa.cerclis.link'}
+    defaultMessage= {`{resPartyEpaCerclisLink}`}
+    description= {'responsible party link for EPA CERCLIS'}
+    values={{
+      resPartyEpaCerclisLink:
+      <a href={`https://enviro.epa.gov/facts/rcrainfo/search.html`}
+        target={'_blank'}
+        rel="noreferrer">
+        {`
+          Environmental Protection Agency (EPA) CERCLIS database as compiled by EPA’s EJSCREEN        
+        `}
+      </a>,
+    }}
+  />,
+  EPA_RMP: <FormattedMessage
+    id= {'category.resp.party.epa.rmp.link'}
+    defaultMessage= {`{resPartyEpaRmpLink}`}
+    description= {'responsible party link for EPA RMP'}
+    values={{
+      resPartyEpaRmpLink:
+      <a href={`https://www.epa.gov/ejscreen/technical-documentation-ejscreen`}
+        target={'_blank'}
+        rel="noreferrer">
+        {`
+          Environmental Protection Agency (EPA) RMP database as compiled by EPA’s EJSCREEN        
+        `}
+      </a>,
+    }}
+  />,
+  EPA_RSEI: <FormattedMessage
+    id= {'category.resp.party.epa.rsei.link'}
+    defaultMessage= {`{resPartyEpaRseiLink}`}
+    description= {'responsible party link for EPA RSEI'}
+    values={{
+      resPartyEpaRseiLink:
+      <a href={`https://www.epa.gov/ejscreen/technical-documentation-ejscreen`}
+        target={'_blank'}
+        rel="noreferrer">
+        {`
+          Environmental Protection Agency (EPA) Risk-Screening
+          Environmental Indicators (RSEI) Model as compiled by EPA's EJSCREEN        
+        `}
+      </a>,
+    }}
+  />,
+  CDC_PLACES: <FormattedMessage
+    id= {'category.resp.party.cdc.places.link'}
+    defaultMessage= {`{resPartyCdcPlacesLink}`}
+    description= {'responsible party link for CDC Places'}
+    values={{
+      resPartyCdcPlacesLink:
+      <a href={`https://www.cdc.gov/places/index.html`}
+        target={'_blank'}
+        rel="noreferrer">
+        {`
+          Centers for Disease Control and Prevention (CDC) PLACES        
+        `}
+      </a>,
+    }}
+  />,
+  CDC_SLEEP: <FormattedMessage
+    id= {'category.resp.party.cdc.sleep.link'}
+    defaultMessage= {`{resPartyCdcSleepLink}`}
+    description= {'responsible party link for CDC Sleep'}
+    values={{
+      resPartyCdcSleepLink:
+      <a href={`https://www.cdc.gov/nchs/nvss/usaleep/usaleep.html#data`}
+        target={'_blank'}
+        rel="noreferrer">
+        {`
+          CDC’s U.S. Small-area Life Expectancy Estimates Project (USALEEP)        
+        `}
+      </a>,
+    }}
+  />,
+};
+
+export const DATE_RANGE = {
+  TEN_PLUS_5: '2010-2015',
+  FOURTEEN: '2014',
+  FOURTEEN_PLUS_4: '2014-2018',
+  FOURTEEN_PLUS_7: '2014-2021',
+  FIFETEEN_PLUS_4: '2015-2019',
+  SIXTEEN_PLUS_3: '2016-2019',
+  SIXTEEN_PLUS_4: '2016-2020',
+  SEVENTEEN: '2017',
+  EIGHTEEN: '2018',
+  TWENTY: '2020',
+};
+
 export const INDICATORS = [
   {
     domID: 'low-income',
     indicator: 'Low income',
-    description: `
-    Percent of a block group's population in households where household income is at or below
-    200% of the federal poverty level.
-    `,
-    usedIn:
-      <FormattedMessage
-        id= {'category.low.income.used.in'}
-        defaultMessage= {`All methodologies except for training and workforce development`}
-        description= {'used in text for low income'}
-      />,
-    respPartyLabel:
-      <FormattedMessage
-        id= {'category.low.income.resp.party.label'}
-        defaultMessage= {'{lowIncResPartyLinkText}.'}
-        description= {'responsible party label for low.income'}
-        values= {{
-          lowIncResPartyLinkText: `Census's American Community Survey`,
-        }}
-      />,
-    dataSourceURL: `https://www.census.gov/programs-surveys/acs`,
-    dateRange: `2015-2019`,
+    description: <FormattedMessage
+      id= {'category.low.income.description.text'}
+      defaultMessage= {`
+        Percent of a census tract's population in households where household income is at or below
+        200% of the federal poverty level.
+      `}
+      description= {'description text for low income'}
+    />,
+    usedIn: CATEGORIES.ALL.METHODOLOGY,
+    responsibleParty: RESPONSIBLE_PARTIES.CENSUS_ACS,
+    dateRange: DATE_RANGE.FIFETEEN_PLUS_4,
   },
   {
     domID: 'exp-agr-loss-rate',
     indicator: 'Expected agriculture loss rate',
-    description: `
-      Percent of agriculture value at risk from losses due to natural hazards. Calculated by dividing 
-      the agriculture value at risk in a census tract by the total agriculture value in that census 
-      tract. Fourteen natural hazards that have some link to climate change include: avalanche, 
-      coastal flooding, cold wave, drought, hail, heat wave, hurricane, ice storm, landslide, 
-      riverine flooding, strong wind, tornado, wildfire, and winter weather.
-    `,
-    usedIn: `Climate change methodology`,
-    respPartyLabel: `Federal Emergency Management Agency (FEMA)`,
-    dataSourceURL: `https://hazards.fema.gov/nri/expected-annual-loss`,
-    dateRange: `2014-2021`,
+    description: <FormattedMessage
+      id= {'category.exp.agr.loss.rate.description.text'}
+      defaultMessage= {`
+        Percent of agriculture value at risk from losses due to natural hazards. Calculated by dividing 
+        the agriculture value at risk in a census tract by the total agriculture value in that census 
+        tract. Fourteen natural hazards that have some link to climate change include: avalanche, 
+        coastal flooding, cold wave, drought, hail, heat wave, hurricane, ice storm, landslide, 
+        riverine flooding, strong wind, tornado, wildfire, and winter weather.
+      `}
+      description= {'description text for exp agr loss rate'}
+    />,
+    usedIn: CATEGORIES.CLIMATE_CHANGE.METHODOLOGY,
+    responsibleParty: RESPONSIBLE_PARTIES.FEMA,
+    dateRange: DATE_RANGE.FOURTEEN_PLUS_7,
   },
   {
     domID: 'exp-bld-loss-rate',
     indicator: 'Expected building loss rate',
-    description: `
-      Percent of building value at risk from losses due to natural hazards. Calculated by dividing the 
-      building value at risk in a census tract by the total building value in that census tract. 
-      Fourteen natural hazards that have some link to climate change include: avalanche, coastal flooding, 
-      cold wave, drought, hail, heat wave, hurricane, ice storm, landslide, riverine flooding, strong 
-      wind, tornado, wildfire, and winter weather.
-    `,
-    usedIn: `Climate change methodology`,
-    respPartyLabel: `Federal Emergency Management Agency (FEMA)`,
-    dataSourceURL: `https://hazards.fema.gov/nri/expected-annual-loss`,
-    dateRange: `2014-2021`,
+    description: <FormattedMessage
+      id= {'category.exp.bld.loss.rate.description.text'}
+      defaultMessage= {`
+        Percent of building value at risk from losses due to natural hazards. Calculated by dividing the 
+        building value at risk in a census tract by the total building value in that census tract. 
+        Fourteen natural hazards that have some link to climate change include: avalanche, 
+        coastal flooding, cold wave, drought, hail, heat wave, hurricane, ice storm, landslide, 
+        riverine flooding, strong wind, tornado, wildfire, and winter weather.
+        `}
+      description= {'description text for exp bld loss rate'}
+    />,
+    usedIn: CATEGORIES.CLIMATE_CHANGE.METHODOLOGY,
+    responsibleParty: RESPONSIBLE_PARTIES.FEMA,
+    dateRange: DATE_RANGE.FOURTEEN_PLUS_7,
   },
   {
     domID: 'exp-pop-loss-rate',
     indicator: 'Expected population loss rate',
-    description: `
-      Rate relative to the population in fatalities and injuries due to natural hazards each year. 
-      Fourteen natural hazards that have some link to climate change include: avalanche, coastal 
-      flooding, cold wave, drought, hail, heat wave, hurricane, ice storm, landslide, riverine 
-      flooding, strong wind, tornado, wildfire, and winter weather.
-      Population loss is defined as the Spatial Hazard Events and Losses or National Centers 
-      for Environmental Information’s (NCEI) reported number of fatalities and injuries caused by the 
-      hazard occurrence. To combine fatalities and injuries for the computation of population loss value, 
-      an injury is counted as one-tenth (1/10) of a fatality. The NCEI Storm Events Database 
-      classifies injuries and fatalities as direct or indirect. Both direct and indirect injuries 
-      and fatalities are counted as population loss. This total number of injuries and fatalities 
-      is then divided by the population in the census tract to get a per-capita rate of population risk. 
-    
-    `,
-    usedIn: `Climate change methodology`,
-    respPartyLabel: `Federal Emergency Management Agency (FEMA)`,
-    dataSourceURL: `https://hazards.fema.gov/nri/expected-annual-loss`,
-    dateRange: `2014-2021`,
+    description: <FormattedMessage
+      id= {'category.exp.pop.loss.rate.description.text'}
+      defaultMessage= {`
+        Rate relative to the population in fatalities and injuries due to natural hazards each year. 
+        Fourteen natural hazards that have some link to climate change include: avalanche, coastal 
+        flooding, cold wave, drought, hail, heat wave, hurricane, ice storm, landslide, riverine 
+        flooding, strong wind, tornado, wildfire, and winter weather.
+        Population loss is defined as the Spatial Hazard Events and Losses or National Centers 
+        for Environmental Information’s (NCEI) reported number of fatalities and injuries caused by the 
+        hazard occurrence. To combine fatalities and injuries for the computation of population loss value, 
+        an injury is counted as one-tenth (1/10) of a fatality. The NCEI Storm Events Database 
+        classifies injuries and fatalities as direct or indirect. Both direct and indirect injuries 
+        and fatalities are counted as population loss. This total number of injuries and fatalities 
+        is then divided by the population in the census tract to get a per-capita rate of population risk.   
+      `}
+      description= {'description text for exp pop loss rate'}
+    />,
+    usedIn: CATEGORIES.CLIMATE_CHANGE.METHODOLOGY,
+    responsibleParty: RESPONSIBLE_PARTIES.FEMA,
+    dateRange: DATE_RANGE.FOURTEEN_PLUS_7,
   },
   {
     domID: 'energy-burden',
     indicator: 'Energy cost burden',
-    description: `Average annual energy cost ($) divided by household income.`,
-    usedIn: `Clean energy and energy efficiency methodology`,
-    respPartyLabel: `Department of Energy (DOE) LEAD Score`,
-    dataSourceURL: `https://www.energy.gov/eere/slsc/low-income-energy-affordability-data-lead-tool`,
-    dateRange: `2018`,
+    description: <FormattedMessage
+      id= {'category.energy.burden.description.text'}
+      defaultMessage= {`Average annual energy cost ($) divided by household income.`}
+      description= {'description text for energy burden'}
+    />,
+    usedIn: CATEGORIES.CLEAN_ENERGY.METHODOLOGY,
+    responsibleParty: RESPONSIBLE_PARTIES.DOE,
+    dateRange: DATE_RANGE.EIGHTEEN,
   },
   {
     domID: 'pm-25',
     indicator: 'PM2.5 in the air',
-    description: `Fine inhalable particles, with diameters that are generally
-    2.5 micrometers and smaller.`,
-    usedIn: `Clean energy and energy efficiency methodology`,
-    respPartyLabel: `Environmental Protection Agency (EPA) Office of Air
-    and Radiation (OAR) fusion of model and monitor data as compiled by EPA's EJSCREEN`,
-    dataSourceURL: `https://www.epa.gov/ejscreen/technical-documentation-ejscreen`,
-    dateRange: `2017`,
+    description: <FormattedMessage
+      id= {'category.pm2.5.description.text'}
+      defaultMessage= {`
+        Fine inhalable particles, with diameters that are generally 2.5 micrometers and smaller.
+      `}
+      description= {'description text for pm 2.5'}
+    />,
+    usedIn: CATEGORIES.CLEAN_ENERGY.METHODOLOGY,
+    responsibleParty: RESPONSIBLE_PARTIES.EPA_OAR,
+    dateRange: DATE_RANGE.SEVENTEEN,
   },
   {
     domID: 'diesel-pm',
     indicator: 'Diesel particulate matter exposure',
-    description: `Mixture of particles that is part of diesel exhaust in the air.`,
-    usedIn: `Clean transportation methodology`,
-    respPartyLabel: `Environmental Protection Agency (EPA) National Air Toxics Assessment (NATA)
-    as compiled by EPA's EJSCREEN`,
-    dataSourceURL: `https://www.epa.gov/ejscreen/technical-documentation-ejscreen`,
-    dateRange: `2014`,
+    description: <FormattedMessage
+      id= {'category.diesel.pm.description.text'}
+      defaultMessage= {`
+        Mixture of particles that is part of diesel exhaust in the air.
+      `}
+      description= {'description text for diesel pm'}
+    />,
+    usedIn: CATEGORIES.CLEAN_TRANSPORT.METHODOLOGY,
+    responsibleParty: RESPONSIBLE_PARTIES.EPA_NATA,
+    dateRange: DATE_RANGE.FOURTEEN,
   },
   {
     domID: 'traffic-vol',
     indicator: 'Traffic proximity and volume',
-    description: `Count of vehicles (average annual daily traffic) at major roads
-    within 500 meters, divided by distance in meters (not km).`,
-    usedIn: `Clean transportation methodology`,
-    respPartyLabel: `Department of Transportation (DOT) traffic data as compiled by EPA's EJSCREEN`,
-    dataSourceURL: `https://www.epa.gov/ejscreen/technical-documentation-ejscreen`,
-    dateRange: `2017`,
+    description: <FormattedMessage
+      id= {'category.traffic.vol.description.text'}
+      defaultMessage= {`
+        Count of vehicles (average annual daily traffic) at major roads
+        within 500 meters, divided by distance in meters (not km).
+      `}
+      description= {'description text for traffic volume'}
+    />,
+    usedIn: CATEGORIES.CLEAN_TRANSPORT.METHODOLOGY,
+    responsibleParty: RESPONSIBLE_PARTIES.DOT_EPA,
+    dateRange: DATE_RANGE.SEVENTEEN,
   },
   {
     domID: 'house-burden',
     indicator: 'Housing cost burden',
-    description: `
-      The percent of households in a census tract that are both earning less than 80% of HUD Area Median 
-      Family Income by county and are paying greater than 30% of their income to housing costs.    
-    `,
-    usedIn: `Affordable and sustainable housing methodology`,
-    respPartyLabel: `Department of Housing & Urban Development’s
-    (HUD) Comprehensive Housing Affordability Strategy dataset`,
-    dataSourceURL: `https://www.huduser.gov/portal/datasets/cp.html`,
-    dateRange: `2014-2018`,
+    description: <FormattedMessage
+      id= {'category.house.burden.description.text'}
+      defaultMessage= {`
+        The percent of households in a census tract that are both earning less than 80% of HUD Area Median 
+        Family Income by county and are paying greater than 30% of their income to housing costs.    
+      `}
+      description= {'description text for housing burden'}
+    />,
+    usedIn: CATEGORIES.AFFORDABLE_HOUSING.METHODOLOGY,
+    responsibleParty: RESPONSIBLE_PARTIES.HUD,
+    dateRange: DATE_RANGE.FOURTEEN_PLUS_4,
   },
   {
     domID: 'lead-paint',
     indicator: 'Lead paint',
-    description: `
-      Percent of housing units built pre-1960, used as an indicator of potential lead paint exposure in 
-      tracts with median home values less than 90th percentile    `,
-    usedIn: `Affordable and sustainable housing methodology`,
-    respPartyLabel: `Census's American Community Survey`,
-    dataSourceURL: `https://www.census.gov/programs-surveys/acs`,
-    dateRange: `2015-2019`,
+    description: <FormattedMessage
+      id= {'category.lead.paint.description.text'}
+      defaultMessage= {`
+        Percent of housing units built pre-1960, used as an indicator of potential lead paint exposure in 
+        tracts with median home values less than 90th percentile
+      `}
+      description= {'description text for lead paint'}
+    />,
+    usedIn: CATEGORIES.AFFORDABLE_HOUSING.METHODOLOGY,
+    responsibleParty: RESPONSIBLE_PARTIES.CENSUS_ACS,
+    dateRange: DATE_RANGE.FIFETEEN_PLUS_4,
   },
   {
     domID: 'median-home',
     indicator: 'Low median home value',
-    description: `Median home value of owner-occupied housing units in the census tract.`,
-    usedIn: `Affordable and sustainable housing methodology`,
-    respPartyLabel: `Census's American Community Survey`,
-    dataSourceURL: `https://www.census.gov/programs-surveys/acs`,
-    dateRange: `2015-2019`,
+    description: <FormattedMessage
+      id= {'category.lead.paint.description.text'}
+      defaultMessage= {`
+        Median home value of owner-occupied housing units in the census tract.
+       `}
+      description= {'description text for lead paint'}
+    />,
+    usedIn: CATEGORIES.AFFORDABLE_HOUSING.METHODOLOGY,
+    responsibleParty: RESPONSIBLE_PARTIES.CENSUS_ACS,
+    dateRange: DATE_RANGE.FIFETEEN_PLUS_4,
   },
   {
     domID: 'prox-haz',
     indicator: 'Proximity to hazardous waste facilities',
-    description: `
-      Count of hazardous waste facilities (Treatment, Storage, and Disposal Facilities and Large
-      Quantity Generators) within 5 km (or nearest beyond 5 km), each divided by distance in kilometers.
-    `,
-    usedIn: `Reduction and remediation of legacy pollution methodology`,
-    respPartyLabel: `
-      Environmental Protection Agency (EPA) Treatment Storage, and Disposal Facilities
-      (TSDF) data calculated from EPA RCRA info database as compiled by EPA’s EJSCREEN
-    `,
-    dataSourceURL: `https://enviro.epa.gov/facts/rcrainfo/search.html`,
-    dateRange: `2015-2020`,
+    description: <FormattedMessage
+      id= {'category.prox.haz.description.text'}
+      defaultMessage= {`
+        Count of hazardous waste facilities (Treatment, Storage, and Disposal Facilities and Large
+        Quantity Generators) within 5 km (or nearest beyond 5 km), each divided by distance in kilometers.
+      `}
+      description= {'description text for proximity to hazards'}
+    />,
+    usedIn: CATEGORIES.LEGACY_POLLUTION.METHODOLOGY,
+    responsibleParty: RESPONSIBLE_PARTIES.EPA_TSDF,
+    dateRange: DATE_RANGE.TWENTY,
   },
   {
     domID: 'prox-npl',
     indicator: 'Proximity to National Priorities List (NPL) sites',
-    description: `
-    Count of proposed or listed NPL - also known as superfund - sites within 5 km (or nearest one
-      beyond 5 km), each divided by distance in kilometers.`,
-    usedIn: `Reduction and remediation of legacy pollution methodology`,
-    respPartyLabel: `Environmental Protection Agency (EPA) CERCLIS database as compiled by EPA’s EJSCREEN`,
-    dataSourceURL: `https://enviro.epa.gov/facts/rcrainfo/search.html`,
-    dateRange: `2020`,
+    description: <FormattedMessage
+      id= {'category.prox.npl.description.text'}
+      defaultMessage= {`
+        Count of proposed or listed NPL - also known as superfund - sites within 5 km (or nearest one
+        beyond 5 km), each divided by distance in kilometers.      
+        `}
+      description= {'description text for proximity to npl'}
+    />,
+    usedIn: CATEGORIES.LEGACY_POLLUTION.METHODOLOGY,
+    responsibleParty: RESPONSIBLE_PARTIES.EPA_CERCLIS,
+    dateRange: DATE_RANGE.TWENTY,
   },
   {
     domID: 'prox-rmp',
     indicator: 'Proximity to Risk Management Plan (RMP) facilities',
-    description: `
-    Count of RMP (potential chemical accident management plan) facilities within 5 km (or nearest
-      one beyond 5 km), each divided by distance in kilometers.`,
-    usedIn: `Affordable and sustainable housing methodology`,
-    respPartyLabel: `Environmental Protection Agency (EPA) RMP database as compiled by EPA’s EJSCREEN`,
-    dataSourceURL: `https://www.epa.gov/ejscreen/technical-documentation-ejscreen`,
-    dateRange: `2020`,
+    description: <FormattedMessage
+      id= {'category.prox.rmp.description.text'}
+      defaultMessage= {`
+        Count of RMP (potential chemical accident management plan) facilities within 5 km (or nearest
+        one beyond 5 km), each divided by distance in kilometers.
+      `}
+      description= {'description text for proximity to rmp'}
+    />,
+    usedIn: CATEGORIES.LEGACY_POLLUTION.METHODOLOGY_REMEDIATION_ONLY,
+    responsibleParty: RESPONSIBLE_PARTIES.EPA_RMP,
+    dateRange: DATE_RANGE.TWENTY,
   },
   {
     domID: 'waste-water',
     indicator: 'Wastewater discharge',
-    description: `Risk-Screening Environmental Indicators (RSEI) modeled Toxic Concentrations at 
-    stream segments within 500 meters, divided by distance in kilometers (km).`,
-    usedIn: `Critical clean water and waste infrastructure`,
-    respPartyLabel: `Environmental Protection Agency (EPA) Risk-Screening
-    Environmental Indicators (RSEI) Model as compiled by EPA's EJSCREEN`,
-    dataSourceURL: `https://www.epa.gov/ejscreen/technical-documentation-ejscreen`,
-    dateRange: `2020`,
+    description: <FormattedMessage
+      id= {'category.waste.water.description.text'}
+      defaultMessage= {`
+        Risk-Screening Environmental Indicators (RSEI) modeled Toxic Concentrations at 
+        stream segments within 500 meters, divided by distance in kilometers (km).
+      `}
+      description= {'description text for waste water'}
+    />,
+    usedIn: CATEGORIES.CLEAN_WATER.METHODOLOGY,
+    responsibleParty: RESPONSIBLE_PARTIES.EPA_RSEI,
+    dateRange: DATE_RANGE.TWENTY,
   },
   {
     domID: 'asthma',
     indicator: 'Asthma',
-    description: `Weighted percent of people who answer “yes” both
-    to both of the following questions: “Have you ever been told by a doctor,
-    nurse, or other health professional that you have asthma?” and the question
-    “Do you still have asthma?”`,
-    usedIn: `Health burdens methodology`,
-    respPartyLabel: `Centers for Disease Control and Prevention (CDC) PLACES`,
-    dataSourceURL: `https://www.cdc.gov/places/index.html`,
-    dateRange: `2016-2019`,
+    description: <FormattedMessage
+      id= {'category.asthma.description.text'}
+      defaultMessage= {`
+        Weighted percent of people who answer “yes” to both of the following questions: “Have you ever 
+        been told by a doctor, nurse, or other health professional that you have asthma?” and the question
+        “Do you still have asthma?”
+      `}
+      description= {'description text for asthma'}
+    />,
+    usedIn: CATEGORIES.HEALTH_BURDENS.METHODOLOGY,
+    responsibleParty: RESPONSIBLE_PARTIES.CDC_PLACES,
+    dateRange: DATE_RANGE.SIXTEEN_PLUS_3,
   },
   {
     domID: 'diabetes',
     indicator: 'Diabetes',
-    description: `Weighted percent of people ages 18 years and older who report having ever been
-    told by a doctor, nurse, or other health professionals that they have
-    diabetes other than diabetes during pregnancy.`,
-    usedIn: `Health burdens methodology`,
-    respPartyLabel: `Centers for Disease Control and Prevention (CDC) PLACES`,
-    dataSourceURL: `https://www.cdc.gov/places/index.html`,
-    dateRange: `2016-2019`,
+    description: <FormattedMessage
+      id= {'category.diabetes.description.text'}
+      defaultMessage= {`
+        Weighted percent of people ages 18 years and older who report having ever been
+        told by a doctor, nurse, or other health professionals that they have
+        diabetes other than diabetes during pregnancy.
+      `}
+      description= {'description text for diabetes'}
+    />,
+    usedIn: CATEGORIES.HEALTH_BURDENS.METHODOLOGY,
+    responsibleParty: RESPONSIBLE_PARTIES.CDC_PLACES,
+    dateRange: DATE_RANGE.SIXTEEN_PLUS_3,
   },
   {
     domID: 'heart-disease',
     indicator: 'Heart disease',
-    description: `Weighted percent of people ages 18 years and older who report ever having been told
-    by a doctor, nurse, or other health professionals that they had angina or
-    coronary heart disease.`,
-    usedIn: `Health burdens methodology`,
-    respPartyLabel: `Centers for Disease Control and Prevention (CDC) PLACES`,
-    dataSourceURL: `https://www.cdc.gov/places/index.html`,
-    dateRange: `2016-2019`,
+    description: <FormattedMessage
+      id= {'category.diabetes.description.text'}
+      defaultMessage= {`
+        Weighted percent of people ages 18 years and older who report ever having been told
+        by a doctor, nurse, or other health professionals that they had angina or
+        coronary heart disease.
+      `}
+      description= {'description text for diabetes'}
+    />,
+    usedIn: CATEGORIES.HEALTH_BURDENS.METHODOLOGY,
+    responsibleParty: RESPONSIBLE_PARTIES.CDC_PLACES,
+    dateRange: DATE_RANGE.SIXTEEN_PLUS_3,
   },
   {
     domID: 'life-exp',
     indicator: 'Low life expectancy',
-    description: `
-      Average number of years of life a person who has attained a given age can expect to live.
-      Note: Unlike most of the other datasets, high values of this indicator indicate low burdens. 
-      For percentile calculations, the percentile is calculated in reverse order, so that the tract with 
-      the highest median income relative to area median income (lowest burden on this measure) is at the 
-      0th percentile, and the tract with the lowest median income relative to area median income 
-      (highest burden on this measure) is at the 100th percentile.
-    `,
-    usedIn: `Health burdens methodology`,
-    respPartyLabel: `CDC’s U.S. Small-area Life Expectancy Estimates Project (USALEEP)`,
-    dataSourceURL: `https://www.cdc.gov/nchs/nvss/usaleep/usaleep.html#data`,
-    dateRange: `2010-2015`,
+    description: <FormattedMessage
+      id= {'category.low.life.expectancy.description.text'}
+      defaultMessage= {`
+        Average number of years of life a person who has attained a given age can expect to live.
+        {note}
+      `}
+      description= {'description text for low life expectancy'}
+      values= {{
+        note: <p><strong>Note:</strong>{`
+          Unlike most of the other datasets, high values of this indicator indicate low burdens. 
+          For percentile calculations, the percentile is calculated in reverse order, so that the tract with 
+          the highest median income relative to area median income (lowest burden on this measure) is at the 
+          0th percentile, and the tract with the lowest median income relative to area median income 
+          (highest burden on this measure) is at the 100th percentile.
+        `}</p>,
+      }}
+    />,
+    usedIn: CATEGORIES.HEALTH_BURDENS.METHODOLOGY,
+    responsibleParty: RESPONSIBLE_PARTIES.CDC_SLEEP,
+    dateRange: DATE_RANGE.TEN_PLUS_5,
   },
   {
     domID: 'low-med-inc',
     indicator: 'Low median Income',
-    description: `Median income of the census tract calculated as a percent of the area’s median income.`,
-    usedIn: `Training and workforce development`,
-    respPartyLabel: `Census's American Community Survey`,
-    dataSourceURL: `https://www.census.gov/programs-surveys/acs`,
-    dateRange: `2015-2019`,
+    description: <FormattedMessage
+      id= {'category.workforce.dev.description.text'}
+      defaultMessage= {`
+        Median income of the census tract calculated as a percent of the area’s median income.
+      `}
+      description= {'description text for workforce dev'}
+    />,
+    usedIn: CATEGORIES.WORKFORCE_DEV.METHODOLOGY,
+    responsibleParty: RESPONSIBLE_PARTIES.CENSUS_ACS,
+    dateRange: DATE_RANGE.FIFETEEN_PLUS_4,
   },
   {
     domID: 'ling-iso',
     indicator: 'Linguistic Isolation',
-    description: `
-      The percent of limited speaking households, which are households where no one over age 14 speaks English well.
-    `,
-    usedIn: `Training and workforce development`,
-    respPartyLabel: `Census's American Community Survey`,
-    dataSourceURL: `https://www.census.gov/programs-surveys/acs`,
-    dateRange: `2015-2019`,
+    description: <FormattedMessage
+      id= {'category.linguistic.iso.description.text'}
+      defaultMessage= {`
+        The percent of limited speaking households, which are households where no one over age 14 speaks English well.
+      `}
+      description= {'description text for linguistic isolation'}
+    />,
+    usedIn: CATEGORIES.WORKFORCE_DEV.METHODOLOGY,
+    responsibleParty: RESPONSIBLE_PARTIES.CENSUS_ACS,
+    dateRange: DATE_RANGE.FIFETEEN_PLUS_4,
   },
   {
     domID: 'unemploy',
     indicator: 'Unemployment',
-    description: `Number of unemployed people as a percentage of the civilian labor force`,
-    usedIn: `Training and workforce development`,
-    respPartyLabel: `Census's American Community Survey`,
-    dataSourceURL: `https://www.census.gov/programs-surveys/acs`,
-    dateRange: `2015-2019`,
+    description: <FormattedMessage
+      id= {'category.unemploy.description.text'}
+      defaultMessage= {`
+      Number of unemployed people as a percentage of the civilian labor force
+      `}
+      description= {'description text for unemployment'}
+    />,
+    usedIn: CATEGORIES.WORKFORCE_DEV.METHODOLOGY,
+    responsibleParty: RESPONSIBLE_PARTIES.CENSUS_ACS,
+    dateRange: DATE_RANGE.FIFETEEN_PLUS_4,
   },
   {
     domID: 'poverty',
     indicator: 'Poverty',
-    description: `Percent of a tract's population in households where the household income` +
-    ` is at or below 100% of the federal poverty level.`,
-    usedIn: `Training and workforce development`,
-    respPartyLabel: `Census's American Community Survey`,
-    dataSourceURL: `https://www.census.gov/programs-surveys/acs`,
-    dateRange: `2015-2019`,
+    description: <FormattedMessage
+      id= {'category.poverty.description.text'}
+      defaultMessage= {`
+        Percent of a tract's population in households where the household income is at or below 100% of 
+        the federal poverty level.
+      `}
+      description= {'description text for poverty'}
+    />,
+    usedIn: CATEGORIES.WORKFORCE_DEV.METHODOLOGY,
+    responsibleParty: RESPONSIBLE_PARTIES.CENSUS_ACS,
+    dateRange: DATE_RANGE.FIFETEEN_PLUS_4,
   },
   {
     domID: 'high-school',
     indicator: 'High school degree achievement rate',
-    description: `Percent of people ages 25 years or older in a census tract whose
-    education level is less than a high school diploma.`,
-    usedIn: `Training and workforce development`,
-    respPartyLabel: `Census's American Community Survey`,
-    dataSourceURL: `https://www.census.gov/programs-surveys/acs`,
-    dateRange: `2015-2019`,
+    description: <FormattedMessage
+      id= {'category.highschool.description.text'}
+      defaultMessage= {`
+        Percent (not percentile) of people ages 25 years or older in a census tract whose
+        education level is less than a high school diploma.
+      `}
+      description= {'description text for highschool'}
+    />,
+    usedIn: CATEGORIES.WORKFORCE_DEV.METHODOLOGY,
+    responsibleParty: RESPONSIBLE_PARTIES.CENSUS_ACS,
+    dateRange: DATE_RANGE.FIFETEEN_PLUS_4,
+    isPercent: true,
   },
 ];
 

--- a/client/src/data/copy/methodology.tsx
+++ b/client/src/data/copy/methodology.tsx
@@ -374,7 +374,7 @@ export const CATEGORIES = {
     METHODOLOGY: <FormattedMessage
       id= {'indicator.categories.clean.water.methodology'}
       defaultMessage= {`Critical clean water and waste infrastructure`}
-      description= {`Critical clean water and waste infrastructure`}
+      description= {`Critical clean water and waste infrastructure methodology`}
     />,
     TITLE: <FormattedMessage
       id={'indicator.categories.clean.water.title'}

--- a/client/src/data/copy/methodology.tsx
+++ b/client/src/data/copy/methodology.tsx
@@ -333,11 +333,6 @@ export const CATEGORIES = {
       defaultMessage= {`Reduction and remediation of legacy pollution methodology`}
       description= {`Reduction and remediation of legacy pollution methodology`}
     />,
-    METHODOLOGY_REMEDIATION_ONLY: <FormattedMessage
-      id= {'indicator.categories.remediation.methodology'}
-      defaultMessage= {`Remediation of legacy pollution methodology`}
-      description= {`Remediation of legacy pollution methodology`}
-    />,
     TITLE: <FormattedMessage
       id={'indicator.categories.legacy.pollution.title'}
       defaultMessage={'Reduction and remediation of legacy pollution'}
@@ -463,7 +458,7 @@ export const CATEGORIES = {
   WORKFORCE_DEV: {
     METHODOLOGY: <FormattedMessage
       id= {'indicator.categories.workforce.dev.methodology'}
-      defaultMessage= {`Training and workforce development`}
+      defaultMessage= {`Training and workforce development methodology`}
       description= {`Training and workforce development`}
     />,
     TITLE: <FormattedMessage
@@ -979,7 +974,7 @@ export const INDICATORS = [
       `}
       description= {'description text for proximity to rmp'}
     />,
-    usedIn: CATEGORIES.LEGACY_POLLUTION.METHODOLOGY_REMEDIATION_ONLY,
+    usedIn: CATEGORIES.LEGACY_POLLUTION.METHODOLOGY,
     responsibleParty: RESPONSIBLE_PARTIES.EPA_RMP,
     dateRange: DATE_RANGE.TWENTY,
   },

--- a/client/src/pages/__snapshots__/contact.test.tsx.snap
+++ b/client/src/pages/__snapshots__/contact.test.tsx.snap
@@ -150,8 +150,8 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
             This is a beta site. 
           </span>
           <span>
-            It is an early, in-progress version of the tool with limited datasets 
-    that will be continuously updated.
+            It is an early, in-progress version of the tool with limited datasets that will 
+    be regularly updated.
           </span>
         </div>
       </div>

--- a/client/src/pages/__snapshots__/index.test.tsx.snap
+++ b/client/src/pages/__snapshots__/index.test.tsx.snap
@@ -150,8 +150,8 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
             This is a beta site. 
           </span>
           <span>
-            It is an early, in-progress version of the tool with limited datasets 
-    that will be continuously updated.
+            It is an early, in-progress version of the tool with limited datasets that will 
+    be regularly updated.
           </span>
         </div>
       </div>

--- a/client/src/pages/__snapshots__/methodology.test.tsx.snap
+++ b/client/src/pages/__snapshots__/methodology.test.tsx.snap
@@ -1398,7 +1398,7 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                     <span>
                       Used in: 
                     </span>
-                    Remediation of legacy pollution methodology
+                    Reduction and remediation of legacy pollution methodology
                   </li>
                 </ul>
               </div>
@@ -1658,7 +1658,7 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                     <span>
                       Used in: 
                     </span>
-                    Training and workforce development
+                    Training and workforce development methodology
                   </li>
                 </ul>
               </div>
@@ -1696,7 +1696,7 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                     <span>
                       Used in: 
                     </span>
-                    Training and workforce development
+                    Training and workforce development methodology
                   </li>
                 </ul>
               </div>
@@ -1734,7 +1734,7 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                     <span>
                       Used in: 
                     </span>
-                    Training and workforce development
+                    Training and workforce development methodology
                   </li>
                 </ul>
               </div>
@@ -1773,7 +1773,7 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                     <span>
                       Used in: 
                     </span>
-                    Training and workforce development
+                    Training and workforce development methodology
                   </li>
                 </ul>
               </div>
@@ -1812,7 +1812,7 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                     <span>
                       Used in: 
                     </span>
-                    Training and workforce development
+                    Training and workforce development methodology
                   </li>
                 </ul>
               </div>

--- a/client/src/pages/__snapshots__/methodology.test.tsx.snap
+++ b/client/src/pages/__snapshots__/methodology.test.tsx.snap
@@ -150,8 +150,8 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
             This is a beta site. 
           </span>
           <span>
-            It is an early, in-progress version of the tool with limited datasets 
-    that will be continuously updated.
+            It is an early, in-progress version of the tool with limited datasets that will 
+    be regularly updated.
           </span>
         </div>
       </div>
@@ -575,7 +575,7 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
             low median home value
           </a>
            is at or less than
-        90th percentile OR at or above the 10th percentile for the 
+        90th percentile OR at or above the 90th percentile for the 
           <a
             href="#house-burden"
           >
@@ -836,9 +836,9 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                 </h3>
                 <div>
                   
-    Percent of a block group's population in households where household income is at or below
-    200% of the federal poverty level.
-    
+        Percent of a census tract's population in households where household income is at or below
+        200% of the federal poverty level.
+      
                 </div>
                 <ul>
                   <li>
@@ -850,7 +850,7 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                       rel="noreferrer"
                       target="_blank"
                     >
-                      Census's American Community Survey.
+                      Census's American Community Survey
                     </a>
                   </li>
                   <li>
@@ -875,12 +875,12 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                 </h3>
                 <div>
                   
-      Percent of agriculture value at risk from losses due to natural hazards. Calculated by dividing 
-      the agriculture value at risk in a census tract by the total agriculture value in that census 
-      tract. Fourteen natural hazards that have some link to climate change include: avalanche, 
-      coastal flooding, cold wave, drought, hail, heat wave, hurricane, ice storm, landslide, 
-      riverine flooding, strong wind, tornado, wildfire, and winter weather.
-    
+        Percent of agriculture value at risk from losses due to natural hazards. Calculated by dividing 
+        the agriculture value at risk in a census tract by the total agriculture value in that census 
+        tract. Fourteen natural hazards that have some link to climate change include: avalanche, 
+        coastal flooding, cold wave, drought, hail, heat wave, hurricane, ice storm, landslide, 
+        riverine flooding, strong wind, tornado, wildfire, and winter weather.
+      
                 </div>
                 <ul>
                   <li>
@@ -917,12 +917,12 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                 </h3>
                 <div>
                   
-      Percent of building value at risk from losses due to natural hazards. Calculated by dividing the 
-      building value at risk in a census tract by the total building value in that census tract. 
-      Fourteen natural hazards that have some link to climate change include: avalanche, coastal flooding, 
-      cold wave, drought, hail, heat wave, hurricane, ice storm, landslide, riverine flooding, strong 
-      wind, tornado, wildfire, and winter weather.
-    
+        Percent of building value at risk from losses due to natural hazards. Calculated by dividing the 
+        building value at risk in a census tract by the total building value in that census tract. 
+        Fourteen natural hazards that have some link to climate change include: avalanche, 
+        coastal flooding, cold wave, drought, hail, heat wave, hurricane, ice storm, landslide, 
+        riverine flooding, strong wind, tornado, wildfire, and winter weather.
+        
                 </div>
                 <ul>
                   <li>
@@ -959,19 +959,18 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                 </h3>
                 <div>
                   
-      Rate relative to the population in fatalities and injuries due to natural hazards each year. 
-      Fourteen natural hazards that have some link to climate change include: avalanche, coastal 
-      flooding, cold wave, drought, hail, heat wave, hurricane, ice storm, landslide, riverine 
-      flooding, strong wind, tornado, wildfire, and winter weather.
-      Population loss is defined as the Spatial Hazard Events and Losses or National Centers 
-      for Environmental Information’s (NCEI) reported number of fatalities and injuries caused by the 
-      hazard occurrence. To combine fatalities and injuries for the computation of population loss value, 
-      an injury is counted as one-tenth (1/10) of a fatality. The NCEI Storm Events Database 
-      classifies injuries and fatalities as direct or indirect. Both direct and indirect injuries 
-      and fatalities are counted as population loss. This total number of injuries and fatalities 
-      is then divided by the population in the census tract to get a per-capita rate of population risk. 
-    
-    
+        Rate relative to the population in fatalities and injuries due to natural hazards each year. 
+        Fourteen natural hazards that have some link to climate change include: avalanche, coastal 
+        flooding, cold wave, drought, hail, heat wave, hurricane, ice storm, landslide, riverine 
+        flooding, strong wind, tornado, wildfire, and winter weather.
+        Population loss is defined as the Spatial Hazard Events and Losses or National Centers 
+        for Environmental Information’s (NCEI) reported number of fatalities and injuries caused by the 
+        hazard occurrence. To combine fatalities and injuries for the computation of population loss value, 
+        an injury is counted as one-tenth (1/10) of a fatality. The NCEI Storm Events Database 
+        classifies injuries and fatalities as direct or indirect. Both direct and indirect injuries 
+        and fatalities are counted as population loss. This total number of injuries and fatalities 
+        is then divided by the population in the census tract to get a per-capita rate of population risk.   
+      
                 </div>
                 <ul>
                   <li>
@@ -1043,8 +1042,9 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                   PM2.5 in the air
                 </h3>
                 <div>
-                  Fine inhalable particles, with diameters that are generally
-    2.5 micrometers and smaller.
+                  
+        Fine inhalable particles, with diameters that are generally 2.5 micrometers and smaller.
+      
                 </div>
                 <ul>
                   <li>
@@ -1056,8 +1056,11 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                       rel="noreferrer"
                       target="_blank"
                     >
-                      Environmental Protection Agency (EPA) Office of Air
-    and Radiation (OAR) fusion of model and monitor data as compiled by EPA's EJSCREEN
+                      
+          Environmental Protection Agency (EPA) Office of Air and Radiation (OAR) fusion of model and monitor 
+          data as compiled by EPA's EJSCREEN, sourced from EPA National Air Toxics Assessment (NATA), 2017 
+          U.S. Department of Transportation (DOT) traffic data
+        
                     </a>
                   </li>
                   <li>
@@ -1081,7 +1084,9 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                   Diesel particulate matter exposure
                 </h3>
                 <div>
-                  Mixture of particles that is part of diesel exhaust in the air.
+                  
+        Mixture of particles that is part of diesel exhaust in the air.
+      
                 </div>
                 <ul>
                   <li>
@@ -1093,8 +1098,10 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                       rel="noreferrer"
                       target="_blank"
                     >
-                      Environmental Protection Agency (EPA) National Air Toxics Assessment (NATA)
-    as compiled by EPA's EJSCREEN
+                      
+          Environmental Protection Agency (EPA) National Air Toxics Assessment (NATA)
+          as compiled by EPA's EJSCREEN        
+        
                     </a>
                   </li>
                   <li>
@@ -1118,8 +1125,10 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                   Traffic proximity and volume
                 </h3>
                 <div>
-                  Count of vehicles (average annual daily traffic) at major roads
-    within 500 meters, divided by distance in meters (not km).
+                  
+        Count of vehicles (average annual daily traffic) at major roads
+        within 500 meters, divided by distance in meters (not km).
+      
                 </div>
                 <ul>
                   <li>
@@ -1131,7 +1140,9 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                       rel="noreferrer"
                       target="_blank"
                     >
-                      Department of Transportation (DOT) traffic data as compiled by EPA's EJSCREEN
+                      
+          Department of Transportation (DOT) traffic data as compiled by EPA's EJSCREEN      
+        
                     </a>
                   </li>
                   <li>
@@ -1156,9 +1167,9 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                 </h3>
                 <div>
                   
-      The percent of households in a census tract that are both earning less than 80% of HUD Area Median 
-      Family Income by county and are paying greater than 30% of their income to housing costs.    
-    
+        The percent of households in a census tract that are both earning less than 80% of HUD Area Median 
+        Family Income by county and are paying greater than 30% of their income to housing costs.    
+      
                 </div>
                 <ul>
                   <li>
@@ -1170,8 +1181,10 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                       rel="noreferrer"
                       target="_blank"
                     >
-                      Department of Housing & Urban Development’s
-    (HUD) Comprehensive Housing Affordability Strategy dataset
+                      
+          Department of Housing & Urban Development’s
+          (HUD) Comprehensive Housing Affordability Strategy dataset
+        
                     </a>
                   </li>
                   <li>
@@ -1196,8 +1209,9 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                 </h3>
                 <div>
                   
-      Percent of housing units built pre-1960, used as an indicator of potential lead paint exposure in 
-      tracts with median home values less than 90th percentile    
+        Percent of housing units built pre-1960, used as an indicator of potential lead paint exposure in 
+        tracts with median home values less than 90th percentile
+      
                 </div>
                 <ul>
                   <li>
@@ -1233,7 +1247,9 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                   Low median home value
                 </h3>
                 <div>
-                  Median home value of owner-occupied housing units in the census tract.
+                  
+        Median home value of owner-occupied housing units in the census tract.
+       
                 </div>
                 <ul>
                   <li>
@@ -1270,9 +1286,9 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                 </h3>
                 <div>
                   
-      Count of hazardous waste facilities (Treatment, Storage, and Disposal Facilities and Large
-      Quantity Generators) within 5 km (or nearest beyond 5 km), each divided by distance in kilometers.
-    
+        Count of hazardous waste facilities (Treatment, Storage, and Disposal Facilities and Large
+        Quantity Generators) within 5 km (or nearest beyond 5 km), each divided by distance in kilometers.
+      
                 </div>
                 <ul>
                   <li>
@@ -1285,16 +1301,16 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                       target="_blank"
                     >
                       
-      Environmental Protection Agency (EPA) Treatment Storage, and Disposal Facilities
-      (TSDF) data calculated from EPA RCRA info database as compiled by EPA’s EJSCREEN
-    
+          Environmental Protection Agency (EPA) Treatment Storage, and Disposal Facilities
+          (TSDF) data calculated from EPA RCRA info database as compiled by EPA’s EJSCREEN
+        
                     </a>
                   </li>
                   <li>
                     <span>
                       Date range: 
                     </span>
-                    2015-2020
+                    2020
                   </li>
                   <li>
                     <span>
@@ -1312,8 +1328,9 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                 </h3>
                 <div>
                   
-    Count of proposed or listed NPL - also known as superfund - sites within 5 km (or nearest one
-      beyond 5 km), each divided by distance in kilometers.
+        Count of proposed or listed NPL - also known as superfund - sites within 5 km (or nearest one
+        beyond 5 km), each divided by distance in kilometers.      
+        
                 </div>
                 <ul>
                   <li>
@@ -1325,7 +1342,9 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                       rel="noreferrer"
                       target="_blank"
                     >
-                      Environmental Protection Agency (EPA) CERCLIS database as compiled by EPA’s EJSCREEN
+                      
+          Environmental Protection Agency (EPA) CERCLIS database as compiled by EPA’s EJSCREEN        
+        
                     </a>
                   </li>
                   <li>
@@ -1350,8 +1369,9 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                 </h3>
                 <div>
                   
-    Count of RMP (potential chemical accident management plan) facilities within 5 km (or nearest
-      one beyond 5 km), each divided by distance in kilometers.
+        Count of RMP (potential chemical accident management plan) facilities within 5 km (or nearest
+        one beyond 5 km), each divided by distance in kilometers.
+      
                 </div>
                 <ul>
                   <li>
@@ -1363,7 +1383,9 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                       rel="noreferrer"
                       target="_blank"
                     >
-                      Environmental Protection Agency (EPA) RMP database as compiled by EPA’s EJSCREEN
+                      
+          Environmental Protection Agency (EPA) RMP database as compiled by EPA’s EJSCREEN        
+        
                     </a>
                   </li>
                   <li>
@@ -1376,7 +1398,7 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                     <span>
                       Used in: 
                     </span>
-                    Affordable and sustainable housing methodology
+                    Remediation of legacy pollution methodology
                   </li>
                 </ul>
               </div>
@@ -1387,8 +1409,10 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                   Wastewater discharge
                 </h3>
                 <div>
-                  Risk-Screening Environmental Indicators (RSEI) modeled Toxic Concentrations at 
-    stream segments within 500 meters, divided by distance in kilometers (km).
+                  
+        Risk-Screening Environmental Indicators (RSEI) modeled Toxic Concentrations at 
+        stream segments within 500 meters, divided by distance in kilometers (km).
+      
                 </div>
                 <ul>
                   <li>
@@ -1400,8 +1424,10 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                       rel="noreferrer"
                       target="_blank"
                     >
-                      Environmental Protection Agency (EPA) Risk-Screening
-    Environmental Indicators (RSEI) Model as compiled by EPA's EJSCREEN
+                      
+          Environmental Protection Agency (EPA) Risk-Screening
+          Environmental Indicators (RSEI) Model as compiled by EPA's EJSCREEN        
+        
                     </a>
                   </li>
                   <li>
@@ -1425,10 +1451,11 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                   Asthma
                 </h3>
                 <div>
-                  Weighted percent of people who answer “yes” both
-    to both of the following questions: “Have you ever been told by a doctor,
-    nurse, or other health professional that you have asthma?” and the question
-    “Do you still have asthma?”
+                  
+        Weighted percent of people who answer “yes” to both of the following questions: “Have you ever 
+        been told by a doctor, nurse, or other health professional that you have asthma?” and the question
+        “Do you still have asthma?”
+      
                 </div>
                 <ul>
                   <li>
@@ -1440,7 +1467,9 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                       rel="noreferrer"
                       target="_blank"
                     >
-                      Centers for Disease Control and Prevention (CDC) PLACES
+                      
+          Centers for Disease Control and Prevention (CDC) PLACES        
+        
                     </a>
                   </li>
                   <li>
@@ -1464,9 +1493,11 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                   Diabetes
                 </h3>
                 <div>
-                  Weighted percent of people ages 18 years and older who report having ever been
-    told by a doctor, nurse, or other health professionals that they have
-    diabetes other than diabetes during pregnancy.
+                  
+        Weighted percent of people ages 18 years and older who report having ever been
+        told by a doctor, nurse, or other health professionals that they have
+        diabetes other than diabetes during pregnancy.
+      
                 </div>
                 <ul>
                   <li>
@@ -1478,7 +1509,9 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                       rel="noreferrer"
                       target="_blank"
                     >
-                      Centers for Disease Control and Prevention (CDC) PLACES
+                      
+          Centers for Disease Control and Prevention (CDC) PLACES        
+        
                     </a>
                   </li>
                   <li>
@@ -1502,9 +1535,11 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                   Heart disease
                 </h3>
                 <div>
-                  Weighted percent of people ages 18 years and older who report ever having been told
-    by a doctor, nurse, or other health professionals that they had angina or
-    coronary heart disease.
+                  
+        Weighted percent of people ages 18 years and older who report ever having been told
+        by a doctor, nurse, or other health professionals that they had angina or
+        coronary heart disease.
+      
                 </div>
                 <ul>
                   <li>
@@ -1516,7 +1551,9 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                       rel="noreferrer"
                       target="_blank"
                     >
-                      Centers for Disease Control and Prevention (CDC) PLACES
+                      
+          Centers for Disease Control and Prevention (CDC) PLACES        
+        
                     </a>
                   </li>
                   <li>
@@ -1541,13 +1578,22 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                 </h3>
                 <div>
                   
-      Average number of years of life a person who has attained a given age can expect to live.
-      Note: Unlike most of the other datasets, high values of this indicator indicate low burdens. 
-      For percentile calculations, the percentile is calculated in reverse order, so that the tract with 
-      the highest median income relative to area median income (lowest burden on this measure) is at the 
-      0th percentile, and the tract with the lowest median income relative to area median income 
-      (highest burden on this measure) is at the 100th percentile.
-    
+        Average number of years of life a person who has attained a given age can expect to live.
+        
+                  <p>
+                    <strong>
+                      Note:
+                    </strong>
+                    
+          Unlike most of the other datasets, high values of this indicator indicate low burdens. 
+          For percentile calculations, the percentile is calculated in reverse order, so that the tract with 
+          the highest median income relative to area median income (lowest burden on this measure) is at the 
+          0th percentile, and the tract with the lowest median income relative to area median income 
+          (highest burden on this measure) is at the 100th percentile.
+        
+                  </p>
+                  
+      
                 </div>
                 <ul>
                   <li>
@@ -1559,7 +1605,9 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                       rel="noreferrer"
                       target="_blank"
                     >
-                      CDC’s U.S. Small-area Life Expectancy Estimates Project (USALEEP)
+                      
+          CDC’s U.S. Small-area Life Expectancy Estimates Project (USALEEP)        
+        
                     </a>
                   </li>
                   <li>
@@ -1583,7 +1631,9 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                   Low median Income
                 </h3>
                 <div>
-                  Median income of the census tract calculated as a percent of the area’s median income.
+                  
+        Median income of the census tract calculated as a percent of the area’s median income.
+      
                 </div>
                 <ul>
                   <li>
@@ -1620,8 +1670,8 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                 </h3>
                 <div>
                   
-      The percent of limited speaking households, which are households where no one over age 14 speaks English well.
-    
+        The percent of limited speaking households, which are households where no one over age 14 speaks English well.
+      
                 </div>
                 <ul>
                   <li>
@@ -1657,7 +1707,9 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                   Unemployment
                 </h3>
                 <div>
-                  Number of unemployed people as a percentage of the civilian labor force
+                  
+      Number of unemployed people as a percentage of the civilian labor force
+      
                 </div>
                 <ul>
                   <li>
@@ -1693,7 +1745,10 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                   Poverty
                 </h3>
                 <div>
-                  Percent of a tract's population in households where the household income is at or below 100% of the federal poverty level.
+                  
+        Percent of a tract's population in households where the household income is at or below 100% of 
+        the federal poverty level.
+      
                 </div>
                 <ul>
                   <li>
@@ -1729,8 +1784,10 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                   High school degree achievement rate
                 </h3>
                 <div>
-                  Percent of people ages 25 years or older in a census tract whose
-    education level is less than a high school diploma.
+                  
+        Percent (not percentile) of people ages 25 years or older in a census tract whose
+        education level is less than a high school diploma.
+      
                 </div>
                 <ul>
                   <li>

--- a/client/src/styles/global.scss
+++ b/client/src/styles/global.scss
@@ -293,6 +293,12 @@ This section will outline styles that are component specific
   }
 }
 
+// This is to allow the first child in the accordions which is the header showing INDICATOR and 
+// PERCENTILE (0-100) to push into the container's margin to match mock
+.usa-accordion__content > *:first-child {
+  margin: -10px -20px 10px -20px;
+}
+
 /* 
 ***************************************
 *      TIMELINE / PROCESS LIST STYLES

--- a/docs/decisions/0002-mapping-visualization-library.md
+++ b/docs/decisions/0002-mapping-visualization-library.md
@@ -108,6 +108,7 @@ We provide more detail on these factors below.
 - **Popularity** : According to [NPM Trends](https://www.npmtrends.com/mapbox-gl-vs-leaflet-vs-ol-vs-arcgis-js-api-vs-maplibre-gl) Mapbox-GL is the most downloaded package among those considered. More info [here](https://www.geoapify.com/map-libraries-comparison-leaflet-vs-mapbox-gl-vs-openlayers-trends-and-statistics)
   ![Download Stats](./0002-files/MapDownloadCount.png)
 
+<!-- markdown-link-check-disable -->
 #### Mapbox-GL JS Cons
 
 - **Licensing** : Mapbox's December 2020 [announcement](https://github.com/mapbox/mapbox-gl-js/releases/tag/v2.0.0) of version 2.0 of their software changed ther license to proprietary and changed their pricing scheme to cover tiles loaded from outside of their service. This decision was met with [some criticism](https://joemorrison.medium.com/death-of-an-open-source-business-model-62bc227a7e9b) in the open-source mapping community.

--- a/docs/decisions/0004-client-side-framework.md
+++ b/docs/decisions/0004-client-side-framework.md
@@ -75,7 +75,7 @@ Cons:
 
 Pros:
 
-- By far the most commonly framework in this list - 1.4MM [total downloads](https://www.npmtrends.com/gatsby-vs-next-vs-nuxt-vs-vuepress-vs-create-react-app-vs-gridsome) as of May 2, 2021 . Gatsby, the second most-downloaded, has ~470,000
+- By far the most commonly framework in this list - 1.4MM total downloads as of May 2, 2021 . Gatsby, the second most-downloaded, has ~470,000
 - Used by a number of well-known [companies and brands](https://nextjs.org/showcase)
 - Flexible
 - Mature tooling like `create-next-app`

--- a/docs/decisions/0004-client-side-framework.md
+++ b/docs/decisions/0004-client-side-framework.md
@@ -49,11 +49,11 @@ Chosen option: Gatsby, because it seems to hit the balance between being simple 
 - Fairly good [documentation](https://www.gatsbyjs.com/docs)
 
 ### Negative Consequences <!-- optional -->
-
+<!-- markdown-link-check-disable -->
 - Test development environment ran out of memory. We debugged this further and could not replicate the problem on a new machine, but the original experience was annoying to work around and this [article](https://support.gatsbyjs.com/hc/en-us/articles/360053096273-Why-did-I-hit-Out-of-Memory-errors-) suggests it could be a more widespread problem.
 - Local builds and refreshes feel slow compared to other frameworks on this list
 - Seems a little more geared toward the blog usecase
-
+<!-- markdown-link-check-enable -->
 ## Pros and Cons of the Options
 
 ### Jekyll


### PR DESCRIPTION
# Purpose

This PR:
1. adds header to each category
2. can create new paragraphs in methodology cards
3. can link to parts of `Responsible Party` text
4. can link to text in `Used In` text
5. adds Living Copy changes

##  Adds header to each category
This PR will add this to each category:
  ![Screen Shot 2021-12-21 at 7 28 54 PM](https://user-images.githubusercontent.com/86254807/147030718-633af698-a643-4f21-8eb4-e463bc933818.png)

## New paragraphs in methodology cards
It also adds all the outstanding updates from Living Copy. In the Living Copy it was requested to make a separate paragraph for certain cards. This is now possible:

![Screen Shot 2021-12-21 at 7 30 31 PM](https://user-images.githubusercontent.com/86254807/147030881-ab5756e4-f79c-4305-9b22-166e1f5e2614.png)

Maybe we want to break up this paragraph now that we can?

![Screen Shot 2021-12-21 at 7 39 51 PM](https://user-images.githubusercontent.com/86254807/147031655-1bccf06e-1c73-4587-b7bb-1f0facccafe2.png)

## `Responsible Party` text
This PR also allows us now to modify the `Responsible party` links (add link to just a portion of the text rather than the entire text) as some links seem overwhelming (might just be me):

![Screen Shot 2021-12-21 at 7 36 49 PM](https://user-images.githubusercontent.com/86254807/147031365-061c52ff-8992-4577-9397-00abf849cff6.png)

##  Link to text in `Used In`
This PR also allows us to add links to the `Used In` field if it is desired. I thought this would be a nice way to connect it the Categories to the Indicators (if needed). 

closes #1080