### PR TITLE
Run markdown link checker only on markdown changes

### DIFF
--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -1,7 +1,5 @@
 name: Check Markdown links
 on:
-  push:
-    branches: [ main ]
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ main ]

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -1,7 +1,14 @@
 name: Check Markdown links
 on:
   push:
+    branches: [ main ]
   pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ main ]
+    # Run only if the pull request changes a markdown file:
+    # https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#onpushpull_requestpaths
+    paths:
+      - '**.md'
 jobs:
   markdown-link-check:
     runs-on: ubuntu-latest

--- a/mlc_config.json
+++ b/mlc_config.json
@@ -17,6 +17,9 @@
     },
     {
       "pattern": "^https://.*medium.com"
+    },
+    {
+      "pattern": "^https://www.eeoc.gov"
     }
   ],
   "replacementPatterns": [


### PR DESCRIPTION
This makes sure that this action only runs if the pull request is on the main branch and is changing markdown files.

Fixes: https://github.com/usds/justice40-tool/issues/1114