### PR TITLE
Add pyproject.toml to fix docker compose build

### DIFF
--- a/data/data-pipeline/Dockerfile
+++ b/data/data-pipeline/Dockerfile
@@ -35,7 +35,7 @@ ENV PYTHONFAULTHANDLER=1 \
   POETRY_VERSION=1.1.12
 
 WORKDIR /data-pipeline
-COPY pyproject.toml poetry.lock /data-pipeline/
+COPY pyproject.toml /data-pipeline/
 
 RUN pip install "poetry==$POETRY_VERSION"
 RUN poetry config virtualenvs.create false \

--- a/data/data-pipeline/Dockerfile
+++ b/data/data-pipeline/Dockerfile
@@ -35,7 +35,7 @@ ENV PYTHONFAULTHANDLER=1 \
   POETRY_VERSION=1.1.12
 
 WORKDIR /data-pipeline
-COPY poetry.lock /data-pipeline/
+COPY pyproject.toml poetry.lock /data-pipeline/
 
 RUN pip install "poetry==$POETRY_VERSION"
 RUN poetry config virtualenvs.create false \


### PR DESCRIPTION
Even though we want to use locked dependencies, pyproject.toml is still required.

Fixes: https://github.com/usds/justice40-tool/issues/1128