### PR TITLE
Adding github actions to test score and score post

### DIFF
--- a/.github/workflows/test-generate-score.yml
+++ b/.github/workflows/test-generate-score.yml
@@ -34,7 +34,7 @@ jobs:
           aws-region: us-east-1
       - name: Download Score Test Data From AWS
         run: |
-          aws s3 sync s3://justice40-data/data-pipeline-test-data/data/score/datasets/ ./data_pipeline/data/score/datasets/ --delete
+          aws s3 sync s3://justice40-data/data-pipeline-test-data/data/dataset/ ./data_pipeline/data/dataset/ --delete
       - name: Generate Score
         run: |
           poetry run python3 data_pipeline/application.py score-run

--- a/.github/workflows/test-generate-score.yml
+++ b/.github/workflows/test-generate-score.yml
@@ -1,0 +1,47 @@
+name: Test Generate Score
+on:
+  workflow_dispatch:
+    inputs:
+      confirm-action:
+        description: This will run the generate score tests, are you sure you want to proceed? (Y/n)
+        default: n
+        required: true
+jobs:
+  deploy_data:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: data/data-pipeline
+    strategy:
+      matrix:
+        python-version: [3.9]
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v2
+      - name: Print variables to help debug
+        uses: hmarr/debug-action@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Setup Poetry
+        uses: Gr1N/setup-poetry@v7
+      - name: Print poetry version
+        run: poetry --version
+      - name: Install dependencies
+        run: poetry install
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.DATA_DEV_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.DATA_DEV_AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+      - name: Download Score Test Data From AWS
+        run: |
+          aws s3 sync s3://justice40-data/data-pipeline-test-data/data/score/datasets/ ./data_pipeline/data/score/datasets/ --delete
+      - name: Generate Score
+        run: |
+          poetry run python3 data_pipeline/application.py score-run
+      - name: Generate Score Post
+        run: |
+          poetry run python3 data_pipeline/application.py generate-score-post -s aws

--- a/.github/workflows/test-generate-score.yml
+++ b/.github/workflows/test-generate-score.yml
@@ -1,11 +1,7 @@
 name: Test Generate Score
 on:
-  workflow_dispatch:
-    inputs:
-      confirm-action:
-        description: This will run the generate score tests, are you sure you want to proceed? (Y/n)
-        default: n
-        required: true
+  pull_request:
+    branches: [ main ]
 jobs:
   deploy_data:
     runs-on: ubuntu-latest

--- a/.github/workflows/upload-generate-score-test-data.yml
+++ b/.github/workflows/upload-generate-score-test-data.yml
@@ -1,11 +1,7 @@
 name: Upload Generate Score Test Data
 on:
-  workflow_dispatch:
-    inputs:
-      confirm-action:
-        description: This will replace the score test fixtures, are you sure you want to proceed? (Y/n)
-        default: n
-        required: true
+  pull_request:
+    branches: [ main ]
 jobs:
   deploy_data:
     runs-on: ubuntu-latest

--- a/.github/workflows/upload-generate-score-test-data.yml
+++ b/.github/workflows/upload-generate-score-test-data.yml
@@ -1,0 +1,44 @@
+name: Upload Generate Score Test Data
+on:
+  workflow_dispatch:
+    inputs:
+      confirm-action:
+        description: This will replace the score test fixtures, are you sure you want to proceed? (Y/n)
+        default: n
+        required: true
+jobs:
+  deploy_data:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: data/data-pipeline
+    strategy:
+      matrix:
+        python-version: [3.9]
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v2
+      - name: Print variables to help debug
+        uses: hmarr/debug-action@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Setup Poetry
+        uses: Gr1N/setup-poetry@v7
+      - name: Print poetry version
+        run: poetry --version
+      - name: Install dependencies
+        run: poetry install
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.DATA_DEV_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.DATA_DEV_AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+      - name: Run Initial ETLs To Get Source Data
+        run: |
+          poetry run python3 data_pipeline/application.py etl-run
+      - name: Upload Score Test Data To AWS
+        run: |
+          aws s3 sync ./data_pipeline/data/score/datasets/ s3://justice40-data/data-pipeline-test-data/data/score/datasets/ --delete

--- a/.github/workflows/upload-generate-score-test-data.yml
+++ b/.github/workflows/upload-generate-score-test-data.yml
@@ -1,7 +1,11 @@
 name: Upload Generate Score Test Data
 on:
-  pull_request:
-    branches: [ main ]
+  workflow_dispatch:
+    inputs:
+      confirm-action:
+        description: This will reupload the test data used by the Test Generate Score action, are you sure you want to proceed? (Y/n)
+        default: n
+        required: true
 jobs:
   deploy_data:
     runs-on: ubuntu-latest

--- a/.github/workflows/upload-generate-score-test-data.yml
+++ b/.github/workflows/upload-generate-score-test-data.yml
@@ -37,4 +37,4 @@ jobs:
           poetry run python3 data_pipeline/application.py etl-run
       - name: Upload Score Test Data To AWS
         run: |
-          aws s3 sync ./data_pipeline/data/score/datasets/ s3://justice40-data/data-pipeline-test-data/data/score/datasets/ --delete
+          aws s3 sync ./data_pipeline/data/dataset/ s3://justice40-data/data-pipeline-test-data/data/dataset/ --delete


### PR DESCRIPTION
In service of https://github.com/usds/justice40-tool/issues/599

This does not test the etl jobs specific to the datasources. Instead, it takes the "datasets" directory created after all those run and uploads it to s3 in one github action, and downloads it in another. We believe this will take about 8 minutes to run end to end based on https://github.com/usds/justice40-tool/pull/1039#pullrequestreview-830528432.