### PR TITLE
(Work in progress) Adds skipable test with --update_snapshot marker

### DIFF
--- a/data/data-pipeline/conftest.py
+++ b/data/data-pipeline/conftest.py
@@ -1,0 +1,35 @@
+import pytest
+
+
+def pytest_addoption(parser):
+    """Adds --update_snapshots as potential flag that can be parsed from the
+    command line when calling pytest
+    """
+    parser.addoption(
+        "--update_snapshots",
+        action="store_true",
+        default=False,
+        help="Update snapshot test fixtures",
+    )
+
+
+def pytest_configure(config):
+    """Adds update_snapshots to list of available markers to apply to tests"""
+    config.addinivalue_line(
+        "markers",
+        "update_snapshots: mark test as one that updates snapshot fixtures",
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    """Applies pytest.mark.skip to all tests marked with update_snapshots
+    unless the --update_snapshots is passed to the CLI
+    """
+    # if --update_snapshots passed in cli: do not skip slow tests
+    if config.getoption("--update_snapshots"):
+        return
+    # otherwise skip all tests marked with update_snapshots
+    skip = pytest.mark.skip(reason="needs --update_snapshots option to run")
+    for item in items:
+        if "update_snapshots" in item.keywords:
+            item.add_marker(skip)

--- a/data/data-pipeline/conftest.py
+++ b/data/data-pipeline/conftest.py
@@ -2,7 +2,7 @@ import pytest
 
 
 def pytest_addoption(parser):
-    """Adds --update_snapshots as potential flag that can be parsed from the
+    """Adds --update_snapshots as an optional flag that can be parsed from the
     command line when calling pytest
     """
     parser.addoption(
@@ -23,13 +23,18 @@ def pytest_configure(config):
 
 def pytest_collection_modifyitems(config, items):
     """Applies pytest.mark.skip to all tests marked with update_snapshots
-    unless the --update_snapshots is passed to the CLI
+    unless the --update_snapshots flag is passed to the CLI
     """
-    # if --update_snapshots passed in cli: do not skip slow tests
+    # if --update_snapshots passed in cli
     if config.getoption("--update_snapshots"):
-        return
-    # otherwise skip all tests marked with update_snapshots
-    skip = pytest.mark.skip(reason="needs --update_snapshots option to run")
-    for item in items:
-        if "update_snapshots" in item.keywords:
-            item.add_marker(skip)
+        # only run the tests marked with update_snapshots
+        skip = pytest.mark.skip(reason="only updating snapshots")
+        for test in items:
+            if "update_snapshots" not in test.keywords:
+                test.add_marker(skip)
+    else:
+        # otherwise skip all tests marked with update_snapshots
+        skip = pytest.mark.skip(reason="must pass --update_snapshots to run")
+        for test in items:
+            if "update_snapshots" in test.keywords:
+                test.add_marker(skip)

--- a/data/data-pipeline/data_pipeline/etl/score/tests/test_etl_utils.py
+++ b/data/data-pipeline/data_pipeline/etl/score/tests/test_etl_utils.py
@@ -5,6 +5,13 @@ import pytest
 from data_pipeline.etl.score.etl_utils import floor_series
 
 
+@pytest.mark.update_snapshots
+def test_skip_test():
+    """Tests the ability to skip a particular test unless a flag is passed
+    the pytest command"""
+    assert 0
+
+
 def test_floor_series():
     # test examples
     series = pd.Series(data=[None, 1, 0.324534, 1.2341], dtype="float64")

--- a/data/data-pipeline/data_pipeline/tests/base/test_base.py
+++ b/data/data-pipeline/data_pipeline/tests/base/test_base.py
@@ -34,6 +34,13 @@ def load_output_source(etl):
     return df
 
 
+@pytest.mark.update_snapshots
+def test_skip_test():
+    """Tests the ability to skip a particular test unless a flag is passed
+    the pytest command"""
+    assert 0
+
+
 class TemplateETL(ExtractTransformLoad):
     """Mock ETL class that inherits from the base ETL"""
 


### PR DESCRIPTION
## Summary

Creates an "update_snapshots" marker that skips any test which has the decorator @pytest.mark.update_snapshots unless the --update_snapshots flag is passed to pytest in the CLI

## Changes Proposed

- Adds a three functions to a new `conftest.py` at the root of the directory:
  - `pytest_addoption()` Adds `--update_snapshots` as optional flag that can be parsed from the
    command line when calling pytest
  - `pytest_configure` Adds `update_snapshot` as optional marker that can be added to the `@pytest.mark` decorator
  - `pytest_collect_modifyitems()` Applies `@pytest.mark.skip` to all tests marked with `@pytest.mark.update_snapshots`
    unless the `--update_snapshots` flag is passed to the CLI
- Adds a test with the `@pytest.mark.update_snapshots` decorator to each of the main testing directories:
  -  `data_pipeline/etl/scores/tests/`
  - `data_pipeline/tests/`

## Blockers or Questions

- [ ] While this approach anticipates using the same marker (i.e. `update_snapshots`) for all tests that update the snapshot fixtures, we can optionally have separate flags for each data source we want to update, though that would be a bit more involved.
- [x] ~~Currently when the `--update_snapshots` flag is passed to the pytest CLI, it executes both the update_snapshots tests _and_ the other unit tests. We might be able to adjust the `pytest_collect_modifyitems()` function to skip those other tests when `--update_snapshots` is passed, but I'd have to do a bit more experimenting to get that working.~~ Fixed this with the last commit

## Additional Context 

The reason we needed to add a separate `conftest.py` at the root of the project (i.e. next to the `pytest.ini` file is outlined here: https://docs.pytest.org/en/6.2.x/reference.html#pytest.hookspec.pytest_addoption


## Instructions to Review

1.  Run pytest: `poetry run pytest`
2. All tests should pass and 2 tests should be skipped
3. Update snapshot tests: `poetry run pytest --update_snapshots`
4. Both snapshot tests should run and fail 
5. Execute only one snapshot test: `pytest run data_pipeline/tests --update_snapshots`
6. Only the snapshot test in `data_pipeline/tests/` should  run and fail