### PR TITLE
Creating shapefiles for ArcGIS users

### DIFF
--- a/data/data-pipeline/data_pipeline/etl/score/etl_score_geo.py
+++ b/data/data-pipeline/data_pipeline/etl/score/etl_score_geo.py
@@ -1,5 +1,4 @@
 import concurrent.futures
-from hashlib import new
 import math
 
 import pandas as pd

--- a/data/data-pipeline/data_pipeline/etl/score/etl_score_geo.py
+++ b/data/data-pipeline/data_pipeline/etl/score/etl_score_geo.py
@@ -230,7 +230,9 @@ class GeoScoreETL(ExtractTransformLoad):
             logger.info("Producing ESRI shapefiles")
             # Note that esri shapefiles can't have super
             # long column names, so we borrow from the
-            # tile names.
+            # tile names. We reconstruct the dictionary in case:
+            # 1. the set of columns changes, and
+            # 2. the length of column names changes
             # Because these are shortened names, we should
             # also print a key of these names.
             renaming_dictionary = {}
@@ -238,7 +240,7 @@ class GeoScoreETL(ExtractTransformLoad):
                 if column not in constants.TILES_SCORE_COLUMNS:
                     logger.info(f"Missing {column} from geojson data...")
                 else:
-                    # take first 10 characters max
+                    # take first 10 characters, max
                     renaming_dictionary[column] = constants.TILES_SCORE_COLUMNS[
                         column
                     ][:10]

--- a/data/data-pipeline/data_pipeline/etl/score/etl_score_geo.py
+++ b/data/data-pipeline/data_pipeline/etl/score/etl_score_geo.py
@@ -227,13 +227,8 @@ class GeoScoreETL(ExtractTransformLoad):
 
         def write_esri_shapefile():
             logger.info("Producing ESRI shapefiles")
-            # Note that esri shapefiles can't have super
-            # long column names, so we borrow from the
-            # tile names. We reconstruct the dictionary in case:
-            # 1. the set of columns changes, and
-            # 2. the length of column names changes
-            # Because these are shortened names, we should
-            # also print a key of these names.
+            # Note that esri shapefiles can't have long column names, so we borrow from the
+            # shorten some tile names (renaming map) and print out a codebook for the user
             codebook = {}
             renaming_map = {}
 


### PR DESCRIPTION
#1061 

Convert the CEJST data from geojson into ESRI shapefiles so that users who primarily use ArcGIS can easily load the CEJST data into their own tool.