### PR TITLE
Fix broken YML links and add PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE/pull_request_template.md
+++ b/.github/ISSUE_TEMPLATE/pull_request_template.md
@@ -1,0 +1,38 @@
+# Description
+
+Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
+
+Fixes # (issue)
+
+## Type of change
+
+Please delete options that are not relevant.
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update
+
+# How Has This Been Tested?
+
+Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
+
+- [ ] Test A
+- [ ] Test B
+
+**Test Configuration**:
+* Firmware version:
+* Hardware:
+* Toolchain:
+* SDK:
+
+# Checklist:
+
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes
+- [ ] Any dependent changes have been merged and published in downstream modules

--- a/.github/ISSUE_TEMPLATE/pull_request_template.md
+++ b/.github/ISSUE_TEMPLATE/pull_request_template.md
@@ -2,31 +2,15 @@
 
 Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
 
-Fixes # (issue)
+Fixes # (issue number)
 
 ## Type of change
-
-Please delete options that are not relevant.
-
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] This change requires a documentation update
 
-# How Has This Been Tested?
-
-Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-
-- [ ] Test A
-- [ ] Test B
-
-**Test Configuration**:
-* Firmware version:
-* Hardware:
-* Toolchain:
-* SDK:
-
-# Checklist:
+## Checklist:
 
 - [ ] My code follows the style guidelines of this project
 - [ ] I have performed a self-review of my own code

--- a/.github/workflows/compile_mermaid.yml
+++ b/.github/workflows/compile_mermaid.yml
@@ -1,4 +1,4 @@
-name: 'Compile Mermaid in Markdown'
+name: 'Compile Mermaid to MD'
 
 on:
   push:

--- a/.github/workflows/deploy_be_staging.yml
+++ b/.github/workflows/deploy_be_staging.yml
@@ -1,4 +1,4 @@
-name: Deploy Backend staging
+name: Deploy Backend Staging
 on:
   pull_request:
     branches: [main]

--- a/.github/workflows/deploy_fe_staging.yml
+++ b/.github/workflows/deploy_fe_staging.yml
@@ -1,4 +1,4 @@
-name: Deploy Frontend staging
+name: Deploy Frontend Staging
 on:
   pull_request:
     branches: [main]

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,7 +1,7 @@
 # Full command list of cypress github actions:
 #   https://github.com/cypress-io/github-action#cypress-iogithub-action--
 
-name: End to end tests
+name: End to End Tests
 on:
   # To run tests on the push event of a specific branch:
   # push:

--- a/client/README.md
+++ b/client/README.md
@@ -1,5 +1,5 @@
-[![Staging](https://github.com/usds/justice40-tool/actions/workflows/deploy_staging.yml/badge.svg)](https://github.com/usds/justice40-tool/actions/workflows/deploy_staging.yml)
-[![Production](https://github.com/usds/justice40-tool/actions/workflows/deploy_main.yml/badge.svg)](https://github.com/usds/justice40-tool/actions/workflows/deploy_main.yml)
+[![Staging](https://github.com/usds/justice40-tool/actions/workflows/deploy_fe_staging.yml/badge.svg)](https://github.com/usds/justice40-tool/actions/workflows/deploy_fe_staging.yml)
+[![Production](https://github.com/usds/justice40-tool/actions/workflows/deploy_fe_main.yml/badge.svg)](https://github.com/usds/justice40-tool/actions/workflows/deploy_fe_main.yml)
 
 # Justice40 Client
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -16,7 +16,7 @@ In the event that you are interested in updating the architecture of our system,
 
 Provided you have already done this, however, and/or would like to make small changes to the diagram itself, please read on!
 
-This diagram was generated from a text-based markdown-like file using [MermaidJS](https://mermaid-js.github.io/) syntax and the [Compile Mermaid Markdown](https://github.com/marketplace/actions/compile-mermaid-markdown) Github Action.
+This diagram was generated from a text-based markdown-like file using [MermaidJS](https://mermaid-js.github.io/) syntax and the [Compile Mermaid Markdown](https://github.com/neenjaw/compile-mermaid-markdown-action) Github Action.
 
 To update, consult Mermaid syntax [here](https://mermaid-js.github.io/mermaid/#/flowchart) and update the `architecture.mmd` file.
 


### PR DESCRIPTION
I was trying to track the experience of a new person trying to make a contribution. As I tried to do so the build failed due to links failing. I believe these links are failing because we may have updated master directly. I suggest we avoid that.

This PR will
- add a PR template to help OS contributors
- correct broken MD links
- make all YML files follow the same capital case naming scheme