### PR TITLE
Remove color key from Explore the tool page

### DIFF
--- a/client/src/components/Language/Language.tsx
+++ b/client/src/components/Language/Language.tsx
@@ -17,6 +17,12 @@ interface ILanguageProps {
   isDesktop: boolean
 }
 
+/**
+ * Language component that will allow the user to change languages
+ *
+ * @param {boolean} isDesktop
+ * @return {JSX.Element | null}
+ */
 const Language = ({isDesktop}:ILanguageProps) => {
   const flags = useFlags();
 

--- a/client/src/components/MapWrapper/index.tsx
+++ b/client/src/components/MapWrapper/index.tsx
@@ -24,23 +24,6 @@ const MapWrapper = ({location}: IMapWrapperProps) => {
           </div>
         </Grid>
       </Grid>
-
-      <Grid row>
-        <Grid col={7}>
-          <h2>{EXPLORE_COPY.NOTE_ON_TERRITORIES.INTRO}</h2>
-          <p>{EXPLORE_COPY.NOTE_ON_TERRITORIES.PARA_1}</p>
-          <p>{EXPLORE_COPY.NOTE_ON_TERRITORIES.PARA_2}</p>
-          <p>{EXPLORE_COPY.NOTE_ON_TERRITORIES.PARA_3}</p>
-          <p>{EXPLORE_COPY.NOTE_ON_TERRITORIES.PARA_4}</p>
-        </Grid>
-      </Grid>
-
-      <Grid row>
-        <Grid col={7}>
-          <h2>{EXPLORE_COPY.NOTE_ON_TRIBAL_NATIONS.INTRO}</h2>
-          <p>{EXPLORE_COPY.NOTE_ON_TRIBAL_NATIONS.PARA_1}</p>
-        </Grid>
-      </Grid>
     </>
   );
 };

--- a/client/src/components/MapWrapper/index.tsx
+++ b/client/src/components/MapWrapper/index.tsx
@@ -17,12 +17,10 @@ const MapWrapper = ({location}: IMapWrapperProps) => {
         <J40Map location={location}/>
       </Grid>
 
-      <Grid row>
-        <Grid col={7}>
-          <div className={styles.mapCaptionTextLink}>
-            {EXPLORE_COPY.DOWNLOAD_DRAFT.PARAGRAPH_1}
-          </div>
-        </Grid>
+      <Grid desktop={{col: 7}} tablet={{col: 10}} col={12}>
+        <div className={styles.mapCaptionTextLink}>
+          {EXPLORE_COPY.DOWNLOAD_DRAFT.PARAGRAPH_1}
+        </div>
       </Grid>
     </>
   );

--- a/client/src/components/territoryFocusControl.module.scss
+++ b/client/src/components/territoryFocusControl.module.scss
@@ -1,18 +1,20 @@
 @use '../styles/design-system.scss' as *;
 
+@mixin baseTerritoryFocus {
+  position: absolute;
+  left: .75em;
+  z-index: 1;
+}
+
 .territoryFocusContainer {
   // styles for mobile-lg (480px) and greater widths
   @include at-media('mobile-lg') {
-    position: absolute;
-    left: .75em;
+    @include baseTerritoryFocus;
     top: units(card-lg);
-    z-index: 10;
-  }
+  };
 
-  position: absolute;
-  left: .75em;
+  @include baseTerritoryFocus;
   top: units(9);
-  z-index: 10;
 
 }
 

--- a/client/src/pages/cejst.tsx
+++ b/client/src/pages/cejst.tsx
@@ -6,7 +6,6 @@ import HowYouCanHelp from '../components/HowYouCanHelp';
 import J40MainGridContainer from '../components/J40MainGridContainer';
 import Layout from '../components/layout';
 import MapWrapper from '../components/MapWrapper';
-import MapLegend from '../components/MapLegend';
 import PublicEngageButton from '../components/PublicEngageButton';
 
 import * as EXPLORE_COPY from '../data/copy/explore';
@@ -31,15 +30,15 @@ const CEJSTPage = ({location}: IMapPageProps) => {
       </section>
 
       <Grid row gap className={'j40-mb5-mt3'}>
-        <Grid col={12} tablet={{col: 6}}>
+
+        {/* Gradually increase width of description section (desktop = 8 columns, tablet = 20 columns and
+            mobile = 12 columns) */}
+        <Grid desktop={{col: 8}} tablet={{col: 10}} col={12}>
           <section>
             <p>
               {EXPLORE_COPY.PAGE_DESCRIPTION}
             </p>
           </section>
-        </Grid>
-        <Grid col={12} tablet={{col: 6}}>
-          <MapLegend />
         </Grid>
       </Grid>
     </J40MainGridContainer>

--- a/client/src/pages/cejst.tsx
+++ b/client/src/pages/cejst.tsx
@@ -31,9 +31,9 @@ const CEJSTPage = ({location}: IMapPageProps) => {
 
       <Grid row gap className={'j40-mb5-mt3'}>
 
-        {/* Gradually increase width of description section (desktop = 8 columns, tablet = 20 columns and
-            mobile = 12 columns) */}
-        <Grid desktop={{col: 8}} tablet={{col: 10}} col={12}>
+        {/* Gradually increase width of the Grid as the width decreases from desktop to mobile*/}
+        {/* desktop = 7 columns, tablet = 10 columns and mobile = 12 columns (full width) */}
+        <Grid desktop={{col: 7}} tablet={{col: 10}} col={12}>
           <section>
             <p>
               {EXPLORE_COPY.PAGE_DESCRIPTION}
@@ -45,6 +45,21 @@ const CEJSTPage = ({location}: IMapPageProps) => {
 
     <J40MainGridContainer>
       <MapWrapper location={location}/>
+    </J40MainGridContainer>
+
+    <J40MainGridContainer>
+      <Grid desktop={{col: 7}} tablet={{col: 10}} col={12}>
+        <h2>{EXPLORE_COPY.NOTE_ON_TERRITORIES.INTRO}</h2>
+        <p>{EXPLORE_COPY.NOTE_ON_TERRITORIES.PARA_1}</p>
+        <p>{EXPLORE_COPY.NOTE_ON_TERRITORIES.PARA_2}</p>
+        <p>{EXPLORE_COPY.NOTE_ON_TERRITORIES.PARA_3}</p>
+        <p>{EXPLORE_COPY.NOTE_ON_TERRITORIES.PARA_4}</p>
+      </Grid>
+
+      <Grid desktop={{col: 7}} tablet={{col: 10}} col={12}>
+        <h2>{EXPLORE_COPY.NOTE_ON_TRIBAL_NATIONS.INTRO}</h2>
+        <p>{EXPLORE_COPY.NOTE_ON_TRIBAL_NATIONS.PARA_1}</p>
+      </Grid>
     </J40MainGridContainer>
 
     <J40MainGridContainer>


### PR DESCRIPTION
## Tickets this PR closes
- #1432 

## QA review

### QA review link is [here](http://usds-geoplatform-justice40-website.s3-website-us-east-1.amazonaws.com/justice40-tool/1484-3c26c9/en/cejst/#3/33.47/-97.5)

### QA tester
- [x] Kameron
- [ ] Katherine
- [ ] Beth

### QA spec 
- [x] is the color key removed?
- [x] is the description text a sufficient width on desktop?
- [x] is the description text a sufficient width on mobile?
- [x] do the text sections below the map have the correct width on mobile?
- [x] do the text sections below the map have the correct width on desktop?