### PR TITLE
Update copy for higher ed and high school

### DIFF
--- a/client/src/components/AreaDetail/AreaDetail.tsx
+++ b/client/src/components/AreaDetail/AreaDetail.tsx
@@ -200,8 +200,8 @@ const AreaDetail = ({properties}:IAreaDetailProps) => {
   const higherEd:indicatorInfo = {
     label: intl.formatMessage(EXPLORE_COPY.SIDE_PANEL_INDICATORS.HIGH_ED),
     description: intl.formatMessage(EXPLORE_COPY.SIDE_PANEL_INDICATOR_DESCRIPTION.HIGH_ED),
-    value: properties.hasOwnProperty(constants.HIGHER_ED_PERCENTILE) ?
-      properties[constants.HIGHER_ED_PERCENTILE] : null,
+    value: properties.hasOwnProperty(constants.NON_HIGHER_ED_PERCENTILE) ?
+      properties[constants.NON_HIGHER_ED_PERCENTILE] : null,
     isDisadvagtaged: properties[constants.IS_HIGHER_ED_PERCENTILE] ?
       properties[constants.IS_HIGHER_ED_PERCENTILE] : null,
     isPercent: true,

--- a/client/src/components/AreaDetail/AreaDetail.tsx
+++ b/client/src/components/AreaDetail/AreaDetail.tsx
@@ -205,7 +205,7 @@ const AreaDetail = ({properties}:IAreaDetailProps) => {
     isDisadvagtaged: properties[constants.IS_HIGHER_ED_PERCENTILE] ?
       properties[constants.IS_HIGHER_ED_PERCENTILE] : null,
     isPercent: true,
-    threshold: 20,
+    threshold: 80,
   };
 
   const energyBurden:indicatorInfo = {
@@ -365,7 +365,7 @@ const AreaDetail = ({properties}:IAreaDetailProps) => {
     value: getWorkForceIndicatorValue('highSchool'),
     isDisadvagtaged: getWorkForceIndicatorIsDisadv('highSchool'),
     isPercent: true,
-    threshold: 90,
+    threshold: 10,
   };
 
   /**

--- a/client/src/components/AreaDetail/tests/__snapshots__/areaDetail.test.tsx.snap
+++ b/client/src/components/AreaDetail/tests/__snapshots__/areaDetail.test.tsx.snap
@@ -248,7 +248,7 @@ exports[`rendering of the AreaDetail checks if indicators for ISLAND AREAS are p
         >
           <div>
             <div>
-              High school degree attainment rate
+              High school degree non-attainment
               <div>
                 
       Percent of people ages 25 years or older whose education level is less than a high school diploma 
@@ -290,7 +290,7 @@ exports[`rendering of the AreaDetail checks if indicators for ISLAND AREAS are p
         >
           <div>
             <div>
-              High school degree attainment rate
+              High school degree non-attainment
               <div>
                 
       Percent of people ages 25 years or older whose education level is less than a high school diploma 
@@ -321,7 +321,7 @@ exports[`rendering of the AreaDetail checks if indicators for ISLAND AREAS are p
         >
           <div>
             <div>
-              Higher ed enrollment rate
+              Higher education non-enrollement
               <div>
                 
       Percent of the census tract's population 15 or older not enrolled in college, university, or 
@@ -622,7 +622,7 @@ exports[`rendering of the AreaDetail checks if indicators for NATION is present 
         >
           <div>
             <div>
-              Higher ed enrollment rate
+              Higher education non-enrollement
               <div>
                 
       Percent of the census tract's population 15 or older not enrolled in college, university, or 
@@ -799,7 +799,7 @@ exports[`rendering of the AreaDetail checks if indicators for NATION is present 
         >
           <div>
             <div>
-              Higher ed enrollment rate
+              Higher education non-enrollement
               <div>
                 
       Percent of the census tract's population 15 or older not enrolled in college, university, or 
@@ -976,7 +976,7 @@ exports[`rendering of the AreaDetail checks if indicators for NATION is present 
         >
           <div>
             <div>
-              Higher ed enrollment rate
+              Higher education non-enrollement
               <div>
                 
       Percent of the census tract's population 15 or older not enrolled in college, university, or 
@@ -1165,7 +1165,7 @@ exports[`rendering of the AreaDetail checks if indicators for NATION is present 
         >
           <div>
             <div>
-              Higher ed enrollment rate
+              Higher education non-enrollement
               <div>
                 
       Percent of the census tract's population 15 or older not enrolled in college, university, or 
@@ -1371,7 +1371,7 @@ exports[`rendering of the AreaDetail checks if indicators for NATION is present 
         >
           <div>
             <div>
-              Higher ed enrollment rate
+              Higher education non-enrollement
               <div>
                 
       Percent of the census tract's population 15 or older not enrolled in college, university, or 
@@ -1519,7 +1519,7 @@ exports[`rendering of the AreaDetail checks if indicators for NATION is present 
         >
           <div>
             <div>
-              Higher ed enrollment rate
+              Higher education non-enrollement
               <div>
                 
       Percent of the census tract's population 15 or older not enrolled in college, university, or 
@@ -1761,7 +1761,7 @@ exports[`rendering of the AreaDetail checks if indicators for NATION is present 
         >
           <div>
             <div>
-              Higher ed enrollment rate
+              Higher education non-enrollement
               <div>
                 
       Percent of the census tract's population 15 or older not enrolled in college, university, or 
@@ -1990,7 +1990,7 @@ exports[`rendering of the AreaDetail checks if indicators for NATION is present 
         >
           <div>
             <div>
-              High school degree attainment rate
+              High school degree non-attainment
               <div>
                 
       Percent of people ages 25 years or older whose education level is less than a high school diploma 
@@ -2029,7 +2029,7 @@ exports[`rendering of the AreaDetail checks if indicators for NATION is present 
         >
           <div>
             <div>
-              Higher ed enrollment rate
+              Higher education non-enrollement
               <div>
                 
       Percent of the census tract's population 15 or older not enrolled in college, university, or 
@@ -2351,7 +2351,7 @@ exports[`rendering of the AreaDetail checks if indicators for PUERTO RICO are pr
         >
           <div>
             <div>
-              High school degree attainment rate
+              High school degree non-attainment
               <div>
                 
       Percent of people ages 25 years or older whose education level is less than a high school diploma 
@@ -2390,7 +2390,7 @@ exports[`rendering of the AreaDetail checks if indicators for PUERTO RICO are pr
         >
           <div>
             <div>
-              Higher ed enrollment rate
+              Higher education non-enrollement
               <div>
                 
       Percent of the census tract's population 15 or older not enrolled in college, university, or 

--- a/client/src/components/AreaDetail/tests/__snapshots__/areaDetail.test.tsx.snap
+++ b/client/src/components/AreaDetail/tests/__snapshots__/areaDetail.test.tsx.snap
@@ -2014,7 +2014,7 @@ exports[`rendering of the AreaDetail checks if indicators for NATION is present 
               </div>
               <div>
                 <div>
-                  above 90
+                  above 10
                 </div>
                 <div>
                   percent
@@ -2375,7 +2375,7 @@ exports[`rendering of the AreaDetail checks if indicators for PUERTO RICO are pr
               </div>
               <div>
                 <div>
-                  above 90
+                  above 10
                 </div>
                 <div>
                   percent

--- a/client/src/components/Categories/__snapshots__/Categories.test.tsx.snap
+++ b/client/src/components/Categories/__snapshots__/Categories.test.tsx.snap
@@ -72,7 +72,7 @@ exports[`rendering of the Categories checks if component renders 1`] = `
         >
           low income
         </a>
-         AND 80% or more adults 15 or older are not enrolled in 
+         AND 80% or more of adults 15 or older are not enrolled in 
         <a
           href="#high-ed-enroll-rate"
         >
@@ -125,7 +125,7 @@ exports[`rendering of the Categories checks if component renders 1`] = `
         >
           low income
         </a>
-         AND 80% or more adults 15 or older are not enrolled in 
+         AND 80% or more of adults 15 or older are not enrolled in 
         <a
           href="#high-ed-enroll-rate"
         >
@@ -182,7 +182,7 @@ exports[`rendering of the Categories checks if component renders 1`] = `
         >
           low income
         </a>
-         AND 80% or more adults 15 or older are not enrolled in 
+         AND 80% or more of adults 15 or older are not enrolled in 
         <a
           href="#high-ed-enroll-rate"
         >
@@ -241,7 +241,7 @@ exports[`rendering of the Categories checks if component renders 1`] = `
         >
           low income
         </a>
-         AND 80% or more adults 15 or older are not enrolled in 
+         AND 80% or more of adults 15 or older are not enrolled in 
         <a
           href="#high-ed-enroll-rate"
         >
@@ -300,7 +300,7 @@ exports[`rendering of the Categories checks if component renders 1`] = `
         >
           low income
         </a>
-         AND 80% or more adults 15 or older are not enrolled in 
+         AND 80% or more of adults 15 or older are not enrolled in 
         <a
           href="#high-ed-enroll-rate"
         >
@@ -347,7 +347,7 @@ exports[`rendering of the Categories checks if component renders 1`] = `
         >
           low income
         </a>
-         AND 80% or more adults 15 or older are not enrolled in 
+         AND 80% or more of adults 15 or older are not enrolled in 
         <a
           href="#high-ed-enroll-rate"
         >
@@ -412,7 +412,7 @@ exports[`rendering of the Categories checks if component renders 1`] = `
         >
           low income
         </a>
-         AND 80% or more adults 15 or older are not enrolled in 
+         AND 80% or more of adults 15 or older are not enrolled in 
         <a
           href="#high-ed-enroll-rate"
         >

--- a/client/src/components/Categories/__snapshots__/Categories.test.tsx.snap
+++ b/client/src/components/Categories/__snapshots__/Categories.test.tsx.snap
@@ -72,12 +72,11 @@ exports[`rendering of the Categories checks if component renders 1`] = `
         >
           low income
         </a>
-         AND at or below 
-      20% for 
+         AND 80% or more adults 15 or older are not enrolled in 
         <a
           href="#high-ed-enroll-rate"
         >
-          higher ed enrollment rate
+          higher education
         </a>
          
     
@@ -126,12 +125,11 @@ exports[`rendering of the Categories checks if component renders 1`] = `
         >
           low income
         </a>
-         AND at or below 
-      20% for 
+         AND 80% or more adults 15 or older are not enrolled in 
         <a
           href="#high-ed-enroll-rate"
         >
-          higher ed enrollment rate
+          higher education
         </a>
          
     
@@ -184,12 +182,11 @@ exports[`rendering of the Categories checks if component renders 1`] = `
         >
           low income
         </a>
-         AND at or below 
-      20% for 
+         AND 80% or more adults 15 or older are not enrolled in 
         <a
           href="#high-ed-enroll-rate"
         >
-          higher ed enrollment rate
+          higher education
         </a>
          
     
@@ -244,12 +241,11 @@ exports[`rendering of the Categories checks if component renders 1`] = `
         >
           low income
         </a>
-         AND at or below 
-      20% for 
+         AND 80% or more adults 15 or older are not enrolled in 
         <a
           href="#high-ed-enroll-rate"
         >
-          higher ed enrollment rate
+          higher education
         </a>
          
     
@@ -304,12 +300,11 @@ exports[`rendering of the Categories checks if component renders 1`] = `
         >
           low income
         </a>
-         AND at or below 
-      20% for 
+         AND 80% or more adults 15 or older are not enrolled in 
         <a
           href="#high-ed-enroll-rate"
         >
-          higher ed enrollment rate
+          higher education
         </a>
          
     
@@ -352,12 +347,11 @@ exports[`rendering of the Categories checks if component renders 1`] = `
         >
           low income
         </a>
-         AND at or below 
-      20% for 
+         AND 80% or more adults 15 or older are not enrolled in 
         <a
           href="#high-ed-enroll-rate"
         >
-          higher ed enrollment rate
+          higher education
         </a>
          
     
@@ -418,12 +412,11 @@ exports[`rendering of the Categories checks if component renders 1`] = `
         >
           low income
         </a>
-         AND at or below 
-      20% for 
+         AND 80% or more adults 15 or older are not enrolled in 
         <a
           href="#high-ed-enroll-rate"
         >
-          higher ed enrollment rate
+          higher education
         </a>
          
     
@@ -478,17 +471,17 @@ exports[`rendering of the Categories checks if component renders 1`] = `
         <strong>
           AND
         </strong>
-         is at or less than 90% for 
+         10% or more of adults 25 or older have not attained a 
         <a
           href="#high-school"
         >
-          high school degree attainment rate
+          high school degree
         </a>
-         for adults 25 years and older AND at or below 20% for 
+         AND 80% or more of adults 15 or older are not enrolled in 
         <a
           href="#high-ed-enroll-rate"
         >
-          higher ed enrollment rate
+          higher education
         </a>
          
   

--- a/client/src/components/CategoryCard/__snapshots__/CategoryCard.test.tsx.snap
+++ b/client/src/components/CategoryCard/__snapshots__/CategoryCard.test.tsx.snap
@@ -50,7 +50,7 @@ exports[`rendering of the CategoryCard checks if component renders 1`] = `
       >
         low income
       </a>
-       AND 80% or more adults 15 or older are not enrolled in 
+       AND 80% or more of adults 15 or older are not enrolled in 
       <a
         href="#high-ed-enroll-rate"
       >

--- a/client/src/components/CategoryCard/__snapshots__/CategoryCard.test.tsx.snap
+++ b/client/src/components/CategoryCard/__snapshots__/CategoryCard.test.tsx.snap
@@ -50,12 +50,11 @@ exports[`rendering of the CategoryCard checks if component renders 1`] = `
       >
         low income
       </a>
-       AND at or below 
-      20% for 
+       AND 80% or more adults 15 or older are not enrolled in 
       <a
         href="#high-ed-enroll-rate"
       >
-        higher ed enrollment rate
+        higher education
       </a>
        
     

--- a/client/src/components/DatasetContainer/tests/__snapshots__/datasetContainer.test.tsx.snap
+++ b/client/src/components/DatasetContainer/tests/__snapshots__/datasetContainer.test.tsx.snap
@@ -101,11 +101,11 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
               id="high-ed-enroll-rate"
             >
               <h3>
-                Higher ed enrollment rate
+                Higher education non-enrollment
               </h3>
               <div>
                 
-        Percent of people who are currently enrolled in college or graduate school.
+        Percent of people 15 or older who are not currently enrolled in college, university, or graduate school.
       
               </div>
               <ul>
@@ -140,7 +140,7 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                   <span>
                     Available for: 
                   </span>
-                  All U.S. states and the District of Columbia
+                  All U.S. states, the District of Columbia, and Puerto Rico
                 </li>
               </ul>
             </div>
@@ -1308,12 +1308,11 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
               id="high-school"
             >
               <h3>
-                High school degree attainment rate
+                High school degree non-attainment
               </h3>
               <div>
                 
-        Percent of people ages 25 years or older in a census tract whose
-        education level is less than a high school diploma.
+        Percent of people age 25 years or older in a census tract whose education level is less than a high school diploma.
       
               </div>
               <ul>

--- a/client/src/data/constants.tsx
+++ b/client/src/data/constants.tsx
@@ -63,6 +63,8 @@ export const IS_FEDERAL_POVERTY_LEVEL_200 = 'FPL200S';
 export const HIGHER_ED_PERCENTILE = 'CA';
 export const IS_HIGHER_ED_PERCENTILE = 'CA_LT20';
 
+export const NON_HIGHER_ED_PERCENTILE = 'NCA';
+
 
 // Energy category
 export const IS_ENERGY_FACTOR_DISADVANTAGED_M = 'M_ENY';

--- a/client/src/data/copy/explore.tsx
+++ b/client/src/data/copy/explore.tsx
@@ -408,7 +408,7 @@ export const SIDE_PANEL_INDICATORS = defineMessages({
     description: `Navigate to the explore the tool page. When the map is in view, click on the map. The side panel will show low income`},
   HIGH_ED: {
     id: 'explore.tool.page.side.panel.indicator.high.ed',
-    defaultMessage: 'Higher ed enrollment rate',
+    defaultMessage: 'Higher education non-enrollement',
     description: `Navigate to the explore the tool page. When the map is in view, click on the map. The side panel will show Higher ed degree achievement rate
 `,
   },
@@ -509,7 +509,7 @@ export const SIDE_PANEL_INDICATORS = defineMessages({
   },
   HIGH_SCL: {
     id: 'explore.tool.page.side.panel.indicator.high.school',
-    defaultMessage: 'High school degree attainment rate',
+    defaultMessage: 'High school degree non-attainment',
     description: `Navigate to the explore the tool page. When the map is in view, click on the map. The side panel will show High school degree achievement rate`,
   },
 });

--- a/client/src/data/copy/methodology.tsx
+++ b/client/src/data/copy/methodology.tsx
@@ -151,7 +151,7 @@ export const CATEGORY_AND_CLAUSE = {
   LOW_INC_65_WHEN_HIGH_ED_LTE_20: <FormattedMessage
     id= {'methodology.page.category.and.clause.low.inc.hs.ed'}
     defaultMessage={`
-      <boldtag>AND</boldtag> is above the 65th percentile for <link1>low income</link1> AND 80% or more adults 15 or older are not enrolled in <link2>higher education</link2> 
+      <boldtag>AND</boldtag> is above the 65th percentile for <link1>low income</link1> AND 80% or more of adults 15 or older are not enrolled in <link2>higher education</link2> 
     `}
     description= {'Navigate to the methodology page. Navigate to the category section. This is category portion of the formula dealing with lower income and high school degree rate'}
     values= {{

--- a/client/src/data/copy/methodology.tsx
+++ b/client/src/data/copy/methodology.tsx
@@ -151,8 +151,7 @@ export const CATEGORY_AND_CLAUSE = {
   LOW_INC_65_WHEN_HIGH_ED_LTE_20: <FormattedMessage
     id= {'methodology.page.category.and.clause.low.inc.hs.ed'}
     defaultMessage={`
-      <boldtag>AND</boldtag> is above the 65th percentile for <link1>low income</link1> AND at or below 
-      20% for <link2>higher ed enrollment rate</link2> 
+      <boldtag>AND</boldtag> is above the 65th percentile for <link1>low income</link1> AND 80% or more adults 15 or older are not enrolled in <link2>higher education</link2> 
     `}
     description= {'Navigate to the methodology page. Navigate to the category section. This is category portion of the formula dealing with lower income and high school degree rate'}
     values= {{
@@ -163,7 +162,7 @@ export const CATEGORY_AND_CLAUSE = {
   />,
   HS_DEG_90_WHEN_HIGH_ED_LTE_20: <FormattedMessage
     id= {'methodology.page.category.and.clause.hs.ed.higher.ed'}
-    defaultMessage= {`<boldtag>AND</boldtag> is at or less than 90% for <link1>high school degree attainment rate</link1> for adults 25 years and older AND at or below 20% for <link2>higher ed enrollment rate</link2> 
+    defaultMessage= {`<boldtag>AND</boldtag> 10% or more of adults 25 or older have not attained a <link1>high school degree</link1> AND 80% or more of adults 15 or older are not enrolled in <link2>higher education</link2> 
   `}
     description= {'Navigate to the methodology page. Navigate to the category section. This is the portion of the formula dealing with higher ed enrollment and high school degree rate'}
     values= {{
@@ -611,7 +610,7 @@ export const AVAILABLE_FOR = {
 
 export interface IIndicators {
   domID: string,
-  indicator: string,
+  indicator: JSX.Element,
   description: JSX.Element,
   note?: JSX.Element,
   usedIn: JSX.Element,
@@ -625,7 +624,11 @@ export interface IIndicators {
 export const INDICATORS = [
   {
     domID: 'low-income',
-    indicator: 'Low income',
+    indicator: <FormattedMessage
+      id= {'methodology.page.dataset.indicator.low.income.title.text'}
+      defaultMessage= {`Low income`}
+      description= {'Navigate to the Methodology page. This is the title text for the low income dataset'}
+    />,
     description: <FormattedMessage
       id= {'methodology.page.category.low.income.description.text'}
       defaultMessage= {`
@@ -645,26 +648,34 @@ export const INDICATORS = [
   },
   {
     domID: 'high-ed-enroll-rate',
-    indicator: 'Higher ed enrollment rate',
+    indicator: <FormattedMessage
+      id= {'methodology.page.dataset.indicator.high.ed.enroll.title.text'}
+      defaultMessage= {`Higher education non-enrollment`}
+      description= {'Navigate to the Methodology page. This is the title text for the high ed enrollment dataset'}
+    />,
     description: <FormattedMessage
       id= {'methodology.page.category.high.ed.enroll.rate.description.text'}
       defaultMessage= {`
-        Percent of people who are currently enrolled in college or graduate school.
+        Percent of people 15 or older who are not currently enrolled in college, university, or graduate school.
       `}
-      description= {'Navigate to the Methodology page. This is the description text for low income'}
+      description= {'Navigate to the Methodology page. This is the description text for high ed enrollment'}
     />,
     usedIn: CATEGORIES.ALL,
     responsibleParty: RESPONSIBLE_PARTIES.CENSUS,
     sources: [
       {
         source: SOURCE_LINKS.CENSUS_ACS_15_19,
-        availableFor: AVAILABLE_FOR.ALL_US_DC,
+        availableFor: AVAILABLE_FOR.ALL_US_DC_PR,
       },
     ],
   },
   {
     domID: 'exp-agr-loss-rate',
-    indicator: 'Expected agriculture loss rate',
+    indicator: <FormattedMessage
+      id= {'methodology.page.dataset.indicator.expected.ag.loss.title.text'}
+      defaultMessage= {`Expected agriculture loss rate`}
+      description= {'Navigate to the Methodology page. This is the title text for the expected agr loss rate income dataset'}
+    />,
     description: <FormattedMessage
       id= {'methodology.page.category.exp.agr.loss.rate.description.text'}
       defaultMessage= {`
@@ -688,7 +699,11 @@ export const INDICATORS = [
   },
   {
     domID: 'exp-bld-loss-rate',
-    indicator: 'Expected building loss rate',
+    indicator: <FormattedMessage
+      id= {'methodology.page.dataset.indicator.exp.bld.loss.title.text'}
+      defaultMessage= {`Expected building loss rate`}
+      description= {'Navigate to the Methodology page. This is the title text for the exp bld loss income dataset'}
+    />,
     description: <FormattedMessage
       id= {'methodology.page.category.exp.bld.loss.rate.description.text'}
       defaultMessage= {`
@@ -711,7 +726,11 @@ export const INDICATORS = [
   },
   {
     domID: 'exp-pop-loss-rate',
-    indicator: 'Expected population loss rate',
+    indicator: <FormattedMessage
+      id= {'methodology.page.dataset.indicator.exp.pop.loss.title.text'}
+      defaultMessage= {`Expected population loss rate`}
+      description= {'Navigate to the Methodology page. This is the title text for the exp pop loss income dataset'}
+    />,
     description: <FormattedMessage
       id= {'methodology.page.category.exp.pop.loss.rate.description.text'}
       defaultMessage= {`
@@ -741,7 +760,11 @@ export const INDICATORS = [
   },
   {
     domID: 'energy-burden',
-    indicator: 'Energy burden',
+    indicator: <FormattedMessage
+      id= {'methodology.page.dataset.indicator.energy.burden.title.text'}
+      defaultMessage= {`Energy burden`}
+      description= {'Navigate to the Methodology page. This is the title text for the energy burden dataset'}
+    />,
     description: <FormattedMessage
       id= {'methodology.page.category.energy.burden.description.text'}
       defaultMessage= {`Average annual energy cost per household ($) divided by average household income.`}
@@ -758,7 +781,11 @@ export const INDICATORS = [
   },
   {
     domID: 'pm-25',
-    indicator: 'PM2.5 in the air',
+    indicator: <FormattedMessage
+      id= {'methodology.page.dataset.indicator.pm25.title.text'}
+      defaultMessage= {`PM2.5 in the air`}
+      description= {'Navigate to the Methodology page. This is the title text for the pm25 dataset'}
+    />,
     description: <FormattedMessage
       id= {'methodology.page.category.pm2.5.description.text'}
       defaultMessage= {`
@@ -779,7 +806,11 @@ export const INDICATORS = [
   },
   {
     domID: 'diesel-pm',
-    indicator: 'Diesel particulate matter exposure',
+    indicator: <FormattedMessage
+      id= {'methodology.page.dataset.indicator.diesel.pm.title.text'}
+      defaultMessage= {`Diesel particulate matter exposure`}
+      description= {'Navigate to the Methodology page. This is the title text for the diesel pm dataset'}
+    />,
     description: <FormattedMessage
       id= {'methodology.page.category.diesel.pm.description.text'}
       defaultMessage= {`
@@ -799,7 +830,11 @@ export const INDICATORS = [
   },
   {
     domID: 'traffic-vol',
-    indicator: 'Traffic proximity and volume',
+    indicator: <FormattedMessage
+      id= {'methodology.page.dataset.indicator.traffic.volume.title.text'}
+      defaultMessage= {`Traffic proximity and volume`}
+      description= {'Navigate to the Methodology page. This is the title text for the traffic.volume dataset'}
+    />,
     description: <FormattedMessage
       id= {'methodology.page.category.traffic.vol.description.text'}
       defaultMessage= {`
@@ -819,7 +854,11 @@ export const INDICATORS = [
   },
   {
     domID: 'house-burden',
-    indicator: 'Housing cost burden',
+    indicator: <FormattedMessage
+      id= {'methodology.page.dataset.indicator.house.burden.title.text'}
+      defaultMessage= {`Housing cost burden`}
+      description= {'Navigate to the Methodology page. This is the title text for the house burden dataset'}
+    />,
     description: <FormattedMessage
       id= {'methodology.page.category.house.burden.description.text'}
       defaultMessage= {`
@@ -839,7 +878,11 @@ export const INDICATORS = [
   },
   {
     domID: 'lead-paint',
-    indicator: 'Lead paint',
+    indicator: <FormattedMessage
+      id= {'methodology.page.dataset.indicator.lead.paint.title.text'}
+      defaultMessage= {`Lead paint`}
+      description= {'Navigate to the Methodology page. This is the title text for the lead paint dataset'}
+    />,
     description: <FormattedMessage
       id= {'methodology.page.category.lead.paint.description.text'}
       defaultMessage= {`
@@ -859,7 +902,11 @@ export const INDICATORS = [
   },
   {
     domID: 'median-home',
-    indicator: 'Median home value',
+    indicator: <FormattedMessage
+      id= {'methodology.page.dataset.indicator.median.home.title.text'}
+      defaultMessage= {`Median home value`}
+      description= {'Navigate to the Methodology page. This is the title text for the median home dataset'}
+    />,
     description: <FormattedMessage
       id= {'methodology.page.category.median.home.value.description.text'}
       defaultMessage= {`
@@ -878,7 +925,11 @@ export const INDICATORS = [
   },
   {
     domID: 'prox-haz',
-    indicator: 'Proximity to hazardous waste facilities',
+    indicator: <FormattedMessage
+      id= {'methodology.page.dataset.indicator.prox.haz.title.text'}
+      defaultMessage= {`Proximity to hazardous waste facilities`}
+      description= {'Navigate to the Methodology page. This is the title text for the prox haz dataset'}
+    />,
     description: <FormattedMessage
       id= {'methodology.page.category.prox.haz.description.text'}
       defaultMessage= {`
@@ -899,7 +950,11 @@ export const INDICATORS = [
   },
   {
     domID: 'prox-npl',
-    indicator: 'Proximity to National Priorities List (NPL) sites',
+    indicator: <FormattedMessage
+      id= {'methodology.page.dataset.indicator.prox.npl.title.text'}
+      defaultMessage= {`Proximity to National Priorities List (NPL) sites`}
+      description= {'Navigate to the Methodology page. This is the title text for the prox npl dataset'}
+    />,
     description: <FormattedMessage
       id= {'methodology.page.category.prox.npl.description.text'}
       defaultMessage= {`
@@ -919,7 +974,11 @@ export const INDICATORS = [
   },
   {
     domID: 'prox-rmp',
-    indicator: 'Proximity to Risk Management Plan (RMP) facilities',
+    indicator: <FormattedMessage
+      id= {'methodology.page.dataset.indicator.prox.rpm.title.text'}
+      defaultMessage= {`Proximity to Risk Management Plan (RMP) facilities`}
+      description= {'Navigate to the Methodology page. This is the title text for the prox rpm dataset'}
+    />,
     description: <FormattedMessage
       id= {'methodology.page.category.prox.rmp.description.text'}
       defaultMessage= {`
@@ -939,7 +998,11 @@ export const INDICATORS = [
   },
   {
     domID: 'waste-water',
-    indicator: 'Wastewater discharge',
+    indicator: <FormattedMessage
+      id= {'methodology.page.dataset.indicator.waste.water.title.text'}
+      defaultMessage= {`Wastewater discharge`}
+      description= {'Navigate to the Methodology page. This is the title text for the waste water dataset'}
+    />,
     description: <FormattedMessage
       id= {'methodology.page.category.waste.water.description.text'}
       defaultMessage= {`
@@ -959,7 +1022,11 @@ export const INDICATORS = [
   },
   {
     domID: 'asthma',
-    indicator: 'Asthma',
+    indicator: <FormattedMessage
+      id= {'methodology.page.dataset.indicator.asthma.title.text'}
+      defaultMessage= {`Asthma`}
+      description= {'Navigate to the Methodology page. This is the title text for the asthma dataset'}
+    />,
     description: <FormattedMessage
       id= {'methodology.page.category.asthma.description.text'}
       defaultMessage= {`
@@ -980,7 +1047,11 @@ export const INDICATORS = [
   },
   {
     domID: 'diabetes',
-    indicator: 'Diabetes',
+    indicator: <FormattedMessage
+      id= {'methodology.page.dataset.indicator.diabetes.title.text'}
+      defaultMessage= {`Diabetes`}
+      description= {'Navigate to the Methodology page. This is the title text for the diabetes dataset'}
+    />,
     description: <FormattedMessage
       id= {'methodology.page.category.diabetes.description.text'}
       defaultMessage= {`
@@ -1001,7 +1072,11 @@ export const INDICATORS = [
   },
   {
     domID: 'heart-disease',
-    indicator: 'Heart disease',
+    indicator: <FormattedMessage
+      id= {'methodology.page.dataset.indicator.heart.disease.title.text'}
+      defaultMessage= {`Heart disease`}
+      description= {'Navigate to the Methodology page. This is the title text for the heart disease dataset'}
+    />,
     description: <FormattedMessage
       id= {'methodology.page.category.heart.disease.description.text'}
       defaultMessage= {`
@@ -1022,7 +1097,11 @@ export const INDICATORS = [
   },
   {
     domID: 'life-exp',
-    indicator: 'Low life expectancy',
+    indicator: <FormattedMessage
+      id= {'methodology.page.dataset.indicator.life.exp.title.text'}
+      defaultMessage= {`Low life expectancy`}
+      description= {'Navigate to the Methodology page. This is the title text for the life exp dataset'}
+    />,
     description: <FormattedMessage
       id= {'methodology.page.category.low.life.expectancy.description.text'}
       defaultMessage= {`
@@ -1051,7 +1130,11 @@ export const INDICATORS = [
   },
   {
     domID: 'low-med-inc',
-    indicator: 'Low median income',
+    indicator: <FormattedMessage
+      id= {'methodology.page.dataset.indicator.low.median.income.title.text'}
+      defaultMessage= {`Low median income`}
+      description= {'Navigate to the Methodology page. This is the title text for the low median income dataset'}
+    />,
     description: <FormattedMessage
       id= {'methodology.page.category.workforce.dev.description.text'}
       defaultMessage= {`
@@ -1084,7 +1167,11 @@ export const INDICATORS = [
   },
   {
     domID: 'ling-iso',
-    indicator: 'Linguistic isolation',
+    indicator: <FormattedMessage
+      id= {'methodology.page.dataset.indicator.ling.iso.title.text'}
+      defaultMessage= {`Linguistic isolation`}
+      description= {'Navigate to the Methodology page. This is the title text for the linguistic isolation dataset'}
+    />,
     description: <FormattedMessage
       id= {'methodology.page.category.linguistic.iso.description.text'}
       defaultMessage= {`
@@ -1103,7 +1190,11 @@ export const INDICATORS = [
   },
   {
     domID: 'unemploy',
-    indicator: 'Unemployment',
+    indicator: <FormattedMessage
+      id= {'methodology.page.dataset.indicator.unemploy.title.text'}
+      defaultMessage= {`Unemployment`}
+      description= {'Navigate to the Methodology page. This is the title text for the unemployment dataset'}
+    />,
     description: <FormattedMessage
       id= {'methodology.page.category.unemploy.description.text'}
       defaultMessage= {`
@@ -1126,7 +1217,11 @@ export const INDICATORS = [
   },
   {
     domID: 'poverty',
-    indicator: 'Poverty',
+    indicator: <FormattedMessage
+      id= {'methodology.page.dataset.indicator.poverty.title.text'}
+      defaultMessage= {`Poverty`}
+      description= {'Navigate to the Methodology page. This is the title text for the poverty dataset'}
+    />,
     description: <FormattedMessage
       id= {'methodology.page.category.poverty.description.text'}
       defaultMessage= {`
@@ -1150,14 +1245,17 @@ export const INDICATORS = [
   },
   {
     domID: 'high-school',
-    indicator: 'High school degree attainment rate',
+    indicator: <FormattedMessage
+      id= {'methodology.page.dataset.indicator.high.school.title.text'}
+      defaultMessage= {`High school degree non-attainment`}
+      description= {'Navigate to the Methodology page. This is the title text for the high school dataset'}
+    />,
     description: <FormattedMessage
       id= {'methodology.page.category.highschool.description.text'}
       defaultMessage= {`
-        Percent of people ages 25 years or older in a census tract whose
-        education level is less than a high school diploma.
+        Percent of people age 25 years or older in a census tract whose education level is less than a high school diploma.
       `}
-      description= {'Navigate to the Methodology page. This is the description text for highschool'}
+      description= {'Navigate to the Methodology page. This is the description text for high school'}
     />,
     usedIn: CATEGORIES.WORKFORCE_DEV.METHODOLOGY,
     responsibleParty: RESPONSIBLE_PARTIES.CENSUS,

--- a/client/src/intl/en.json
+++ b/client/src/intl/en.json
@@ -784,7 +784,7 @@
     "description": "Navigate to the methodology page. Navigate to the category section. This is the portion of the formula dealing with higher ed enrollment and high school degree rate"
   },
   "methodology.page.category.and.clause.low.inc.hs.ed": {
-    "defaultMessage": "<boldtag>AND</boldtag> is above the 65th percentile for <link1>low income</link1> AND 80% or more adults 15 or older are not enrolled in <link2>higher education</link2>",
+    "defaultMessage": "<boldtag>AND</boldtag> is above the 65th percentile for <link1>low income</link1> AND 80% or more of adults 15 or older are not enrolled in <link2>higher education</link2>",
     "description": "Navigate to the methodology page. Navigate to the category section. This is category portion of the formula dealing with lower income and high school degree rate"
   },
   "methodology.page.category.asthma.description.text": {

--- a/client/src/intl/en.json
+++ b/client/src/intl/en.json
@@ -520,11 +520,11 @@
     "description": "Navigate to the explore the tool page. When the map is in view, click on the map. The side panel will show Heart disease"
   },
   "explore.tool.page.side.panel.indicator.high.ed": {
-    "defaultMessage": "Higher ed enrollment rate",
+    "defaultMessage": "Higher education non-enrollement",
     "description": "Navigate to the explore the tool page. When the map is in view, click on the map. The side panel will show Higher ed degree achievement rate\n"
   },
   "explore.tool.page.side.panel.indicator.high.school": {
-    "defaultMessage": "High school degree attainment rate",
+    "defaultMessage": "High school degree non-attainment",
     "description": "Navigate to the explore the tool page. When the map is in view, click on the map. The side panel will show High school degree achievement rate"
   },
   "explore.tool.page.side.panel.indicator.houseBurden": {
@@ -780,11 +780,11 @@
     "description": "Navigate to the methodology page. This is the methodology page explanation of the categories"
   },
   "methodology.page.category.and.clause.hs.ed.higher.ed": {
-    "defaultMessage": "<boldtag>AND</boldtag> is at or less than 90% for <link1>high school degree attainment rate</link1> for adults 25 years and older AND at or below 20% for <link2>higher ed enrollment rate</link2>",
+    "defaultMessage": "<boldtag>AND</boldtag> 10% or more of adults 25 or older have not attained a <link1>high school degree</link1> AND 80% or more of adults 15 or older are not enrolled in <link2>higher education</link2>",
     "description": "Navigate to the methodology page. Navigate to the category section. This is the portion of the formula dealing with higher ed enrollment and high school degree rate"
   },
   "methodology.page.category.and.clause.low.inc.hs.ed": {
-    "defaultMessage": "<boldtag>AND</boldtag> is above the 65th percentile for <link1>low income</link1> AND at or below 20% for <link2>higher ed enrollment rate</link2>",
+    "defaultMessage": "<boldtag>AND</boldtag> is above the 65th percentile for <link1>low income</link1> AND 80% or more adults 15 or older are not enrolled in <link2>higher education</link2>",
     "description": "Navigate to the methodology page. Navigate to the category section. This is category portion of the formula dealing with lower income and high school degree rate"
   },
   "methodology.page.category.asthma.description.text": {
@@ -824,12 +824,12 @@
     "description": "Navigate to the Methodology page. This is the description text for heart disease"
   },
   "methodology.page.category.high.ed.enroll.rate.description.text": {
-    "defaultMessage": "Percent of people who are currently enrolled in college or graduate school.",
-    "description": "Navigate to the Methodology page. This is the description text for low income"
+    "defaultMessage": "Percent of people 15 or older who are not currently enrolled in college, university, or graduate school.",
+    "description": "Navigate to the Methodology page. This is the description text for high ed enrollment"
   },
   "methodology.page.category.highschool.description.text": {
-    "defaultMessage": "Percent of people ages 25 years or older in a census tract whose education level is less than a high school diploma.",
-    "description": "Navigate to the Methodology page. This is the description text for highschool"
+    "defaultMessage": "Percent of people age 25 years or older in a census tract whose education level is less than a high school diploma.",
+    "description": "Navigate to the Methodology page. This is the description text for high school"
   },
   "methodology.page.category.house.burden.description.text": {
     "defaultMessage": "Percent of households in a census tract that are both earning less than 80% of HUD Area Median Family Income by county and are spending more than 30% of their income on housing costs.",
@@ -954,6 +954,106 @@
   "methodology.page.category.workforce.dev.description.text": {
     "defaultMessage": "Median income of the census tract calculated as a percent of the area’s median income.",
     "description": "Navigate to the Methodology page. This is the description text for workforce dev"
+  },
+  "methodology.page.dataset.indicator.asthma.title.text": {
+    "defaultMessage": "Asthma",
+    "description": "Navigate to the Methodology page. This is the title text for the asthma dataset"
+  },
+  "methodology.page.dataset.indicator.diabetes.title.text": {
+    "defaultMessage": "Diabetes",
+    "description": "Navigate to the Methodology page. This is the title text for the diabetes dataset"
+  },
+  "methodology.page.dataset.indicator.diesel.pm.title.text": {
+    "defaultMessage": "Diesel particulate matter exposure",
+    "description": "Navigate to the Methodology page. This is the title text for the diesel pm dataset"
+  },
+  "methodology.page.dataset.indicator.energy.burden.title.text": {
+    "defaultMessage": "Energy burden",
+    "description": "Navigate to the Methodology page. This is the title text for the energy burden dataset"
+  },
+  "methodology.page.dataset.indicator.exp.bld.loss.title.text": {
+    "defaultMessage": "Expected building loss rate",
+    "description": "Navigate to the Methodology page. This is the title text for the exp bld loss income dataset"
+  },
+  "methodology.page.dataset.indicator.exp.pop.loss.title.text": {
+    "defaultMessage": "Expected population loss rate",
+    "description": "Navigate to the Methodology page. This is the title text for the exp pop loss income dataset"
+  },
+  "methodology.page.dataset.indicator.expected.ag.loss.title.text": {
+    "defaultMessage": "Expected agriculture loss rate",
+    "description": "Navigate to the Methodology page. This is the title text for the expected agr loss rate income dataset"
+  },
+  "methodology.page.dataset.indicator.heart.disease.title.text": {
+    "defaultMessage": "Heart disease",
+    "description": "Navigate to the Methodology page. This is the title text for the heart disease dataset"
+  },
+  "methodology.page.dataset.indicator.high.ed.enroll.title.text": {
+    "defaultMessage": "Higher education non-enrollment",
+    "description": "Navigate to the Methodology page. This is the title text for the high ed enrollment dataset"
+  },
+  "methodology.page.dataset.indicator.high.school.title.text": {
+    "defaultMessage": "High school degree non-attainment",
+    "description": "Navigate to the Methodology page. This is the title text for the high school dataset"
+  },
+  "methodology.page.dataset.indicator.house.burden.title.text": {
+    "defaultMessage": "Housing cost burden",
+    "description": "Navigate to the Methodology page. This is the title text for the house burden dataset"
+  },
+  "methodology.page.dataset.indicator.lead.paint.title.text": {
+    "defaultMessage": "Lead paint",
+    "description": "Navigate to the Methodology page. This is the title text for the lead paint dataset"
+  },
+  "methodology.page.dataset.indicator.life.exp.title.text": {
+    "defaultMessage": "Low life expectancy",
+    "description": "Navigate to the Methodology page. This is the title text for the life exp dataset"
+  },
+  "methodology.page.dataset.indicator.ling.iso.title.text": {
+    "defaultMessage": "Linguistic isolation",
+    "description": "Navigate to the Methodology page. This is the title text for the linguistic isolation dataset"
+  },
+  "methodology.page.dataset.indicator.low.income.title.text": {
+    "defaultMessage": "Low income",
+    "description": "Navigate to the Methodology page. This is the title text for the low income dataset"
+  },
+  "methodology.page.dataset.indicator.low.median.income.title.text": {
+    "defaultMessage": "Low median income",
+    "description": "Navigate to the Methodology page. This is the title text for the low median income dataset"
+  },
+  "methodology.page.dataset.indicator.median.home.title.text": {
+    "defaultMessage": "Median home value",
+    "description": "Navigate to the Methodology page. This is the title text for the median home dataset"
+  },
+  "methodology.page.dataset.indicator.pm25.title.text": {
+    "defaultMessage": "PM2.5 in the air",
+    "description": "Navigate to the Methodology page. This is the title text for the pm25 dataset"
+  },
+  "methodology.page.dataset.indicator.poverty.title.text": {
+    "defaultMessage": "Poverty",
+    "description": "Navigate to the Methodology page. This is the title text for the poverty dataset"
+  },
+  "methodology.page.dataset.indicator.prox.haz.title.text": {
+    "defaultMessage": "Proximity to hazardous waste facilities",
+    "description": "Navigate to the Methodology page. This is the title text for the prox haz dataset"
+  },
+  "methodology.page.dataset.indicator.prox.npl.title.text": {
+    "defaultMessage": "Proximity to National Priorities List (NPL) sites",
+    "description": "Navigate to the Methodology page. This is the title text for the prox npl dataset"
+  },
+  "methodology.page.dataset.indicator.prox.rpm.title.text": {
+    "defaultMessage": "Proximity to Risk Management Plan (RMP) facilities",
+    "description": "Navigate to the Methodology page. This is the title text for the prox rpm dataset"
+  },
+  "methodology.page.dataset.indicator.traffic.volume.title.text": {
+    "defaultMessage": "Traffic proximity and volume",
+    "description": "Navigate to the Methodology page. This is the title text for the traffic.volume dataset"
+  },
+  "methodology.page.dataset.indicator.unemploy.title.text": {
+    "defaultMessage": "Unemployment",
+    "description": "Navigate to the Methodology page. This is the title text for the unemployment dataset"
+  },
+  "methodology.page.dataset.indicator.waste.water.title.text": {
+    "defaultMessage": "Wastewater discharge",
+    "description": "Navigate to the Methodology page. This is the title text for the waste water dataset"
   },
   "methodology.page.datasetCard.available.for": {
     "defaultMessage": "Available for:",

--- a/client/src/pages/__snapshots__/methodology.test.tsx.snap
+++ b/client/src/pages/__snapshots__/methodology.test.tsx.snap
@@ -516,12 +516,11 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
           >
             low income
           </a>
-           AND at or below 
-      20% for 
+           AND 80% or more adults 15 or older are not enrolled in 
           <a
             href="#high-ed-enroll-rate"
           >
-            higher ed enrollment rate
+            higher education
           </a>
            
     
@@ -570,12 +569,11 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
           >
             low income
           </a>
-           AND at or below 
-      20% for 
+           AND 80% or more adults 15 or older are not enrolled in 
           <a
             href="#high-ed-enroll-rate"
           >
-            higher ed enrollment rate
+            higher education
           </a>
            
     
@@ -628,12 +626,11 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
           >
             low income
           </a>
-           AND at or below 
-      20% for 
+           AND 80% or more adults 15 or older are not enrolled in 
           <a
             href="#high-ed-enroll-rate"
           >
-            higher ed enrollment rate
+            higher education
           </a>
            
     
@@ -688,12 +685,11 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
           >
             low income
           </a>
-           AND at or below 
-      20% for 
+           AND 80% or more adults 15 or older are not enrolled in 
           <a
             href="#high-ed-enroll-rate"
           >
-            higher ed enrollment rate
+            higher education
           </a>
            
     
@@ -748,12 +744,11 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
           >
             low income
           </a>
-           AND at or below 
-      20% for 
+           AND 80% or more adults 15 or older are not enrolled in 
           <a
             href="#high-ed-enroll-rate"
           >
-            higher ed enrollment rate
+            higher education
           </a>
            
     
@@ -796,12 +791,11 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
           >
             low income
           </a>
-           AND at or below 
-      20% for 
+           AND 80% or more adults 15 or older are not enrolled in 
           <a
             href="#high-ed-enroll-rate"
           >
-            higher ed enrollment rate
+            higher education
           </a>
            
     
@@ -862,12 +856,11 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
           >
             low income
           </a>
-           AND at or below 
-      20% for 
+           AND 80% or more adults 15 or older are not enrolled in 
           <a
             href="#high-ed-enroll-rate"
           >
-            higher ed enrollment rate
+            higher education
           </a>
            
     
@@ -922,17 +915,17 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
           <strong>
             AND
           </strong>
-           is at or less than 90% for 
+           10% or more of adults 25 or older have not attained a 
           <a
             href="#high-school"
           >
-            high school degree attainment rate
+            high school degree
           </a>
-           for adults 25 years and older AND at or below 20% for 
+           AND 80% or more of adults 15 or older are not enrolled in 
           <a
             href="#high-ed-enroll-rate"
           >
-            higher ed enrollment rate
+            higher education
           </a>
            
   
@@ -1039,11 +1032,11 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                 id="high-ed-enroll-rate"
               >
                 <h3>
-                  Higher ed enrollment rate
+                  Higher education non-enrollment
                 </h3>
                 <div>
                   
-        Percent of people who are currently enrolled in college or graduate school.
+        Percent of people 15 or older who are not currently enrolled in college, university, or graduate school.
       
                 </div>
                 <ul>
@@ -1078,7 +1071,7 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                     <span>
                       Available for: 
                     </span>
-                    All U.S. states and the District of Columbia
+                    All U.S. states, the District of Columbia, and Puerto Rico
                   </li>
                 </ul>
               </div>
@@ -2246,12 +2239,11 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                 id="high-school"
               >
                 <h3>
-                  High school degree attainment rate
+                  High school degree non-attainment
                 </h3>
                 <div>
                   
-        Percent of people ages 25 years or older in a census tract whose
-        education level is less than a high school diploma.
+        Percent of people age 25 years or older in a census tract whose education level is less than a high school diploma.
       
                 </div>
                 <ul>

--- a/client/src/pages/__snapshots__/methodology.test.tsx.snap
+++ b/client/src/pages/__snapshots__/methodology.test.tsx.snap
@@ -516,7 +516,7 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
           >
             low income
           </a>
-           AND 80% or more adults 15 or older are not enrolled in 
+           AND 80% or more of adults 15 or older are not enrolled in 
           <a
             href="#high-ed-enroll-rate"
           >
@@ -569,7 +569,7 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
           >
             low income
           </a>
-           AND 80% or more adults 15 or older are not enrolled in 
+           AND 80% or more of adults 15 or older are not enrolled in 
           <a
             href="#high-ed-enroll-rate"
           >
@@ -626,7 +626,7 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
           >
             low income
           </a>
-           AND 80% or more adults 15 or older are not enrolled in 
+           AND 80% or more of adults 15 or older are not enrolled in 
           <a
             href="#high-ed-enroll-rate"
           >
@@ -685,7 +685,7 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
           >
             low income
           </a>
-           AND 80% or more adults 15 or older are not enrolled in 
+           AND 80% or more of adults 15 or older are not enrolled in 
           <a
             href="#high-ed-enroll-rate"
           >
@@ -744,7 +744,7 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
           >
             low income
           </a>
-           AND 80% or more adults 15 or older are not enrolled in 
+           AND 80% or more of adults 15 or older are not enrolled in 
           <a
             href="#high-ed-enroll-rate"
           >
@@ -791,7 +791,7 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
           >
             low income
           </a>
-           AND 80% or more adults 15 or older are not enrolled in 
+           AND 80% or more of adults 15 or older are not enrolled in 
           <a
             href="#high-ed-enroll-rate"
           >
@@ -856,7 +856,7 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
           >
             low income
           </a>
-           AND 80% or more adults 15 or older are not enrolled in 
+           AND 80% or more of adults 15 or older are not enrolled in 
           <a
             href="#high-ed-enroll-rate"
           >


### PR DESCRIPTION
# Purpose
Update the Higher Ed and High school to have all indicator thresholds in the same direction

## TIckets this PR closes
- closes #1441 

## QA review

### QA review link is [here](http://usds-geoplatform-justice40-website.s3-website-us-east-1.amazonaws.com/justice40-tool/1502-1cf3ed/en/cejst/?flags=stage_hash=1486/95336faee1a14e6764ab3577a4e69a4e5cf34c73#13.96/40.57006/-74.09437)

### QA reviewer
- [x] Kameron
- [ ] Katherine
- [ ] Beth

### QA Spec
- [x] is the Higher ed dataset card correct?
- [x] is the high school dataset card correct?
- [x] is the higher ed title in the side panel correct?
- [x] is the high school title in the side panel correct?

Round 2:
- [x] is the Taskforce category card correct? (AND clause)
- [x] are the AND clause for all category cards correct?
- [x] validate the side panel threshold / values and arrows are correct for higher ed and high school indicators