### PR TITLE
Add TSD and RFI to alert, add link to download slides and reverse events in PEC

### DIFF
--- a/client/src/components/Indicator/Indicator.test.tsx
+++ b/client/src/components/Indicator/Indicator.test.tsx
@@ -93,7 +93,6 @@ describe('test rendering of Indicator value sub-text', () => {
         </LocalizedComponent>,
     );
     expect(asFragment()).toMatchSnapshot();
-    console.log(asFragment());
   });
   it('renders the "below 90 percentile"', () => {
     const {asFragment} = render(

--- a/client/src/components/J40Header/__snapshots__/J40Header.test.tsx.snap
+++ b/client/src/components/J40Header/__snapshots__/J40Header.test.tsx.snap
@@ -369,7 +369,7 @@ exports[`rendering of the J40Header checks if component renders 1`] = `
             >
               sending feedback
             </a>
-             has been extended to May 25, 2022.
+             via the Request for Information has been extended to May 25, 2022.
           </p>
         </div>
       </div>

--- a/client/src/components/J40Header/__snapshots__/J40Header.test.tsx.snap
+++ b/client/src/components/J40Header/__snapshots__/J40Header.test.tsx.snap
@@ -320,7 +320,17 @@ exports[`rendering of the J40Header checks if component renders 1`] = `
           <p
             class="usa-alert__text"
           >
-            Download new technical support and other documentation and 
+            Download new 
+            <a
+              class="usa-link usa-link--external"
+              data-cy=""
+              href="https://static-data-screeningtool.geoplatform.gov/data-pipeline/data/score/downloadable/cejst_technical_support_document.pdf"
+              rel="noreferrer"
+              target="_blank"
+            >
+              technical support
+            </a>
+             and other documentation and 
             <a
               class="usa-link usa-link--external"
               data-cy=""

--- a/client/src/components/LinkTypeWrapper/LinkTypeWrapper.tsx
+++ b/client/src/components/LinkTypeWrapper/LinkTypeWrapper.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
-import {Link} from 'gatsby-plugin-intl';
+import {Link, useIntl} from 'gatsby-plugin-intl';
 import {Link as TrussLink} from '@trussworks/react-uswds';
+
+import {IDefineMessage} from '../../data/copy/common';
 
 interface ILinkTypeWrapper {
     linkText?: string;
     internal?: boolean;
-    url?: string;
+    url: string | IDefineMessage;
     openUrlNewTab?: boolean;
     className?: string;
     dataCy?: string;
@@ -29,9 +31,16 @@ interface ILinkTypeWrapper {
  * @returns
  */
 const LinkTypeWrapper = (props:ILinkTypeWrapper) => {
+  const intl = useIntl();
+  let {url} = props;
+
+  if (url && typeof url !== `string`) {
+    url = intl.formatMessage(url);
+  }
+
   if (props.internal) {
     return (
-      <Link to={`${props.url}`}
+      <Link to={`${url}`}
         className={props.className}
       >
         {props.linkText}
@@ -42,7 +51,7 @@ const LinkTypeWrapper = (props:ILinkTypeWrapper) => {
     <TrussLink
       variant={'external'}
       className={props.className}
-      href={`${props.url}`}
+      href={`${url}`}
       target="_blank"
       rel="noreferrer"
       data-cy={props.dataCy ? props.dataCy : ''}
@@ -51,7 +60,7 @@ const LinkTypeWrapper = (props:ILinkTypeWrapper) => {
     </TrussLink> :
     <a
       className={props.className}
-      href={props.url}
+      href={url}
       data-cy={props.dataCy? props.dataCy : ''}
     >
       {props.linkText}

--- a/client/src/components/PublicEvent/PublicEvent.tsx
+++ b/client/src/components/PublicEvent/PublicEvent.tsx
@@ -36,7 +36,6 @@ const PublicEvent = ({event}:IPublicEvent) => {
 
   const isEventExpired = new Date() > event.DATE;
 
-  console.log('event and date: ', event.NAME, event.DATE, isEventExpired);
   return (
     <CollectionItem
       variantComponent={

--- a/client/src/components/PublicVideoBox/PublicVideoBox.module.scss
+++ b/client/src/components/PublicVideoBox/PublicVideoBox.module.scss
@@ -18,7 +18,7 @@
         @include u-margin-top(3);
         margin-left: auto;
         margin-right: auto;
-
+        width: 14rem;
         
         &:hover {
           @include u-bg("yellow-20");

--- a/client/src/components/PublicVideoBox/PublicVideoBox.tsx
+++ b/client/src/components/PublicVideoBox/PublicVideoBox.tsx
@@ -7,6 +7,8 @@ import * as styles from './PublicVideoBox.module.scss';
 
 // @ts-ignore
 import launchIcon from '/node_modules/uswds/dist/img/usa-icons/launch.svg';
+// @ts-ignore
+import fileDownloadIcon from '/node_modules/uswds/dist/img/usa-icons/file_download.svg';
 
 const PublicVideoBox = () => {
   const intl = useIntl();
@@ -28,12 +30,33 @@ const PublicVideoBox = () => {
         >
           <div className={styles.buttonContainer}>
             <div className={styles.buttonText}>
-              {intl.formatMessage(PUBLIC_COPY.PUBLIC_ENG_VIDEO.BUTTON_TEXT)}
+              {intl.formatMessage(PUBLIC_COPY.PUBLIC_ENG_VIDEO.BUTTON1_TEXT)}
             </div>
             <img
               className={styles.buttonImage}
               src={launchIcon}
-              alt={intl.formatMessage(PUBLIC_COPY.PUBLIC_ENG_VIDEO.IMG_ALT_TEXT)}
+              alt={intl.formatMessage(PUBLIC_COPY.PUBLIC_ENG_VIDEO.IMG_ALT_TEXT1)}
+            />
+          </div>
+        </Button>
+      </a>
+      <a
+        className={styles.publicVideoLink}
+        href={`https://static-data-screeningtool.geoplatform.gov/data-pipeline/data/score/downloadable/technical-training-slides.pptx`}
+        download
+      >
+        <Button
+          type="button"
+          className={styles.youTubeBtn}
+        >
+          <div className={styles.buttonContainer}>
+            <div className={styles.buttonText}>
+              {intl.formatMessage(PUBLIC_COPY.PUBLIC_ENG_VIDEO.BUTTON2_TEXT)}
+            </div>
+            <img
+              className={styles.buttonImage}
+              src={fileDownloadIcon}
+              alt={intl.formatMessage(PUBLIC_COPY.PUBLIC_ENG_VIDEO.IMG_ALT_TEXT2)}
             />
           </div>
         </Button>

--- a/client/src/components/PublicVideoBox/__snapshots__/PublicVideoBox.test.tsx.snap
+++ b/client/src/components/PublicVideoBox/__snapshots__/PublicVideoBox.test.tsx.snap
@@ -39,6 +39,26 @@ exports[`rendering of the PublicVideoBox checks if component renders 1`] = `
             </div>
           </button>
         </a>
+        <a
+          download=""
+          href="https://static-data-screeningtool.geoplatform.gov/data-pipeline/data/score/downloadable/technical-training-slides.pptx"
+        >
+          <button
+            class="usa-button"
+            data-testid="button"
+            type="button"
+          >
+            <div>
+              <div>
+                Download slide deck
+              </div>
+              <img
+                alt="the icon to show that this button will download the file"
+                src="test-file-stub"
+              />
+            </div>
+          </button>
+        </a>
       </div>
     </div>
   </div>

--- a/client/src/components/RequestForInfo/__snapshots__/RequestForInfo.test.tsx.snap
+++ b/client/src/components/RequestForInfo/__snapshots__/RequestForInfo.test.tsx.snap
@@ -41,7 +41,7 @@ exports[`rendering of the RequestForInfo checks if component renders 1`] = `
           >
             sending feedback
           </a>
-           has been extended to May 25, 2022.
+           via the Request for Information has been extended to May 25, 2022.
         </p>
       </div>
     </div>

--- a/client/src/data/copy/common.tsx
+++ b/client/src/data/copy/common.tsx
@@ -5,6 +5,12 @@ import {FormattedDate, FormattedMessage} from 'gatsby-plugin-intl';
 import {defineMessages} from 'react-intl';
 import LinkTypeWrapper from '../../components/LinkTypeWrapper';
 
+export interface IDefineMessage {
+  id: string,
+  defaultMessage: string,
+  description: string,
+};
+
 /*
  * i18n curried functions from react-intl (aka format.js)
  * using ver3 of the docs as this is what gatsby-plugin-intl uses:
@@ -15,9 +21,10 @@ export const italicFn = (str:string) => <i>{str}</i>;
 export const boldFn = (str:string) => <strong>{str}</strong>;
 export const simpleLink = (href:string) => (str:string) => <a href={href}>{str}</a>;
 // eslint-disable-next-line max-len
-export const linkFn = (to:string, isInternal:boolean, isOpenNewTab:boolean) => (str:string) => <LinkTypeWrapper linkText={str} internal={isInternal} url={to} openUrlNewTab={isOpenNewTab}/>;
+export const linkFn = (to:string | IDefineMessage, isInternal:boolean, isOpenNewTab:boolean) => (str:string) => <LinkTypeWrapper linkText={str} internal={isInternal} url={to} openUrlNewTab={isOpenNewTab}/>;
 
 export const FEEDBACK_EMAIL = 'Screeningtool-Support@omb.eop.gov';
+
 
 // Beta Banner
 export const BETA_BANNER = defineMessages({
@@ -34,6 +41,13 @@ export const BETA_BANNER = defineMessages({
   },
 });
 
+export const TSD = defineMessages({
+  URL: {
+    id: 'common.pages.tsd.url',
+    defaultMessage: `https://static-data-screeningtool.geoplatform.gov/data-pipeline/data/score/downloadable/cejst_technical_support_document.pdf`,
+    description: 'Navigate to the Alerts on any page. This will be the link to the techinical support document.',
+  },
+});
 
 // Alerts
 // Expiration month is zero-based: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getMonth
@@ -71,9 +85,10 @@ export const ALERTS = {
   }),
   ALERT_2_DESCRIPTION: <FormattedMessage
     id={'common.pages.alerts.additional_docs_available.description'}
-    defaultMessage={`Download new technical support and other documentation and <link2>send feedback</link2>.`}
+    defaultMessage={`Download new <link1>technical support</link1> and other documentation and <link2>send feedback</link2>.`}
     description={`Alert title that appears at the top of pages.`}
     values={{
+      link1: linkFn(TSD.URL, false, true),
       link2: linkFn(`mailto:${FEEDBACK_EMAIL}`, false, true),
     }}
   />,
@@ -243,3 +258,5 @@ export const CONSOLE_ERROR = defineMessages({
     description: 'Navigate to the about page. This is console error staging URL',
   },
 });
+
+

--- a/client/src/data/copy/common.tsx
+++ b/client/src/data/copy/common.tsx
@@ -63,7 +63,7 @@ export const ALERTS = {
   EXPIRATION_DATE: ALERT_1_EXPIRATION_DATE,
   ALERT_1_DESCRIPTION: <FormattedMessage
     id={'common.pages.alerts.public_comment_period.description'}
-    defaultMessage={`The public comment period for <link1>sending feedback</link1> has been extended to {expDate1}.`}
+    defaultMessage={`The public comment period for <link1>sending feedback</link1> via the Request for Information has been extended to {expDate1}.`}
     description={`Alert body that appears on landing page.`}
     values={{
       link1: linkFn('https://www.federalregister.gov/documents/2022/04/25/2022-08774/climate-and-economic-justice-screening-tool-beta-version', false, true),

--- a/client/src/data/copy/publicEngage.tsx
+++ b/client/src/data/copy/publicEngage.tsx
@@ -79,15 +79,25 @@ export const PUBLIC_ENG_VIDEO = defineMessages({
     defaultMessage: `Watch a recorded version of the CEJST training on YouTube.`,
     description: 'Navigate to the the public engagement page, there will be box that allows users to watch previously recorded videos. This is that box body text.',
   },
-  BUTTON_TEXT: {
-    id: 'public.eng.page.video.box.button.text',
+  BUTTON1_TEXT: {
+    id: 'public.eng.page.video.box.button1.text',
     defaultMessage: `Watch on YouTube`,
     description: 'Navigate to the the public engagement page, there will be box that allows users to watch previously recorded videos. This is that box button text.',
   },
-  IMG_ALT_TEXT: {
-    id: 'public.eng.page.video.box.button.img.alt.text',
+  IMG_ALT_TEXT1: {
+    id: 'public.eng.page.video.box.button.img.alt.text1',
     defaultMessage: `the icon to show that this button will open in a new tab`,
     description: 'Navigate to the the public engagement page, there will be box that allows users to watch previously recorded videos. This is alt tag of the image in the button.',
+  },
+  BUTTON2_TEXT: {
+    id: 'public.eng.page.video.box.button2.text',
+    defaultMessage: `Download slide deck`,
+    description: 'Navigate to the the public engagement page, there will be box that allows users to watch previously recorded videos. This is the button text for the second button.',
+  },
+  IMG_ALT_TEXT2: {
+    id: 'public.eng.page.video.box.button.img.alt.text2',
+    defaultMessage: `the icon to show that this button will download the file`,
+    description: 'Navigate to the the public engagement page, there will be box that allows users to watch previously recorded videos. This is alt tag of the image in the 2nd button.',
   },
 });
 

--- a/client/src/data/copy/publicEngage.tsx
+++ b/client/src/data/copy/publicEngage.tsx
@@ -200,6 +200,7 @@ export const EVENT_FIELDS = defineMessages({
 });
 
 // All events dates are set one day ahead of actual date to account for timezone differences
+// Note: all events in this events in this array must be in chronological order starting with the oldest event.
 export const EVENTS = [
   {
     DATE: new Date(2022, 2, 10),

--- a/client/src/intl/en.json
+++ b/client/src/intl/en.json
@@ -1491,13 +1491,21 @@
     "defaultMessage": "Watch a recorded version of the CEJST training on YouTube.",
     "description": "Navigate to the the public engagement page, there will be box that allows users to watch previously recorded videos. This is that box body text."
   },
-  "public.eng.page.video.box.button.img.alt.text": {
+  "public.eng.page.video.box.button.img.alt.text1": {
     "defaultMessage": "the icon to show that this button will open in a new tab",
     "description": "Navigate to the the public engagement page, there will be box that allows users to watch previously recorded videos. This is alt tag of the image in the button."
   },
-  "public.eng.page.video.box.button.text": {
+  "public.eng.page.video.box.button.img.alt.text2": {
+    "defaultMessage": "the icon to show that this button will download the file",
+    "description": "Navigate to the the public engagement page, there will be box that allows users to watch previously recorded videos. This is alt tag of the image in the 2nd button."
+  },
+  "public.eng.page.video.box.button1.text": {
     "defaultMessage": "Watch on YouTube",
     "description": "Navigate to the the public engagement page, there will be box that allows users to watch previously recorded videos. This is that box button text."
+  },
+  "public.eng.page.video.box.button2.text": {
+    "defaultMessage": "Download slide deck",
+    "description": "Navigate to the the public engagement page, there will be box that allows users to watch previously recorded videos. This is the button text for the second button."
   },
   "public.eng.page.video.box.title.text": {
     "defaultMessage": "Can't make an upcoming session?",

--- a/client/src/intl/en.json
+++ b/client/src/intl/en.json
@@ -92,7 +92,7 @@
     "description": "Navigate to the About page. This is the about page title text"
   },
   "common.pages.alerts.additional_docs_available.description": {
-    "defaultMessage": "Download new technical support and other documentation and <link2>send feedback</link2>.",
+    "defaultMessage": "Download new <link1>technical support</link1> and other documentation and <link2>send feedback</link2>.",
     "description": "Alert title that appears at the top of pages."
   },
   "common.pages.alerts.census.tract.title": {
@@ -230,6 +230,10 @@
   "common.pages.header.tsd": {
     "defaultMessage": "Technical Support Document",
     "description": "Navigate to the about page. This is Header navigate item to the technical support document page"
+  },
+  "common.pages.tsd.url": {
+    "defaultMessage": "https://static-data-screeningtool.geoplatform.gov/data-pipeline/data/score/downloadable/cejst_technical_support_document.pdf",
+    "description": "Navigate to the Alerts on any page. This will be the link to the techinical support document."
   },
   "contact.page.census.tract.feedback.para1": {
     "defaultMessage": "To provide feedback about a specific census tract, either select the send feedback button after selecting a census tract on the <link1>Explore the map</link1> page or use the email address provided above. Please include the census tract ID, county, and state or territory information, in addition to your feedback.",

--- a/client/src/intl/en.json
+++ b/client/src/intl/en.json
@@ -100,7 +100,7 @@
     "description": "Navigate to any page. This the title of the alert that informs the user that new census tract information is available"
   },
   "common.pages.alerts.public_comment_period.description": {
-    "defaultMessage": "The public comment period for <link1>sending feedback</link1> has been extended to {expDate1}.",
+    "defaultMessage": "The public comment period for <link1>sending feedback</link1> via the Request for Information has been extended to {expDate1}.",
     "description": "Alert body that appears on landing page."
   },
   "common.pages.alerts.public_comment_period.title": {

--- a/client/src/pages/public-engagement.tsx
+++ b/client/src/pages/public-engagement.tsx
@@ -16,6 +16,10 @@ interface IPublicEngagementPageProps {
 const PublicEngagementPage = ({location}: IPublicEngagementPageProps) => {
   const intl = useIntl();
 
+  // The reverse() is an in-place algorithm and so a temporary variable is needed:
+  const events = [...PUBLIC_ENG_COPY.EVENTS];
+  events.reverse();
+
   return (
     <Layout location={location} title={intl.formatMessage(PUBLIC_ENG_COPY.PAGE_INTRO.PAGE_TILE)}>
 
@@ -47,7 +51,7 @@ const PublicEngagementPage = ({location}: IPublicEngagementPageProps) => {
         <Grid row gap={6}>
           <Grid desktop={{col: 8}}>
             <Collection>
-              {PUBLIC_ENG_COPY.EVENTS.map((event, index) => <PublicEvent key={index} event={event} />)}
+              {events.map((event, index) => <PublicEvent key={index} event={event} />)}
             </Collection>
           </Grid>
           <Grid desktop={{col: 4}}>

--- a/client/src/pages/tests/__snapshots__/about.test.tsx.snap
+++ b/client/src/pages/tests/__snapshots__/about.test.tsx.snap
@@ -369,7 +369,7 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
             >
               sending feedback
             </a>
-             has been extended to May 25, 2022.
+             via the Request for Information has been extended to May 25, 2022.
           </p>
         </div>
       </div>

--- a/client/src/pages/tests/__snapshots__/about.test.tsx.snap
+++ b/client/src/pages/tests/__snapshots__/about.test.tsx.snap
@@ -320,7 +320,17 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
           <p
             class="usa-alert__text"
           >
-            Download new technical support and other documentation and 
+            Download new 
+            <a
+              class="usa-link usa-link--external"
+              data-cy=""
+              href="https://static-data-screeningtool.geoplatform.gov/data-pipeline/data/score/downloadable/cejst_technical_support_document.pdf"
+              rel="noreferrer"
+              target="_blank"
+            >
+              technical support
+            </a>
+             and other documentation and 
             <a
               class="usa-link usa-link--external"
               data-cy=""

--- a/client/src/pages/tests/__snapshots__/contact.test.tsx.snap
+++ b/client/src/pages/tests/__snapshots__/contact.test.tsx.snap
@@ -369,7 +369,7 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
             >
               sending feedback
             </a>
-             has been extended to May 25, 2022.
+             via the Request for Information has been extended to May 25, 2022.
           </p>
         </div>
       </div>
@@ -522,7 +522,7 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                   >
                     sending feedback
                   </a>
-                   has been extended to May 25, 2022.
+                   via the Request for Information has been extended to May 25, 2022.
                 </p>
               </div>
             </div>

--- a/client/src/pages/tests/__snapshots__/contact.test.tsx.snap
+++ b/client/src/pages/tests/__snapshots__/contact.test.tsx.snap
@@ -320,7 +320,17 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
           <p
             class="usa-alert__text"
           >
-            Download new technical support and other documentation and 
+            Download new 
+            <a
+              class="usa-link usa-link--external"
+              data-cy=""
+              href="https://static-data-screeningtool.geoplatform.gov/data-pipeline/data/score/downloadable/cejst_technical_support_document.pdf"
+              rel="noreferrer"
+              target="_blank"
+            >
+              technical support
+            </a>
+             and other documentation and 
             <a
               class="usa-link usa-link--external"
               data-cy=""

--- a/client/src/pages/tests/__snapshots__/downloads.test.tsx.snap
+++ b/client/src/pages/tests/__snapshots__/downloads.test.tsx.snap
@@ -369,7 +369,7 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
             >
               sending feedback
             </a>
-             has been extended to May 25, 2022.
+             via the Request for Information has been extended to May 25, 2022.
           </p>
         </div>
       </div>

--- a/client/src/pages/tests/__snapshots__/downloads.test.tsx.snap
+++ b/client/src/pages/tests/__snapshots__/downloads.test.tsx.snap
@@ -320,7 +320,17 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
           <p
             class="usa-alert__text"
           >
-            Download new technical support and other documentation and 
+            Download new 
+            <a
+              class="usa-link usa-link--external"
+              data-cy=""
+              href="https://static-data-screeningtool.geoplatform.gov/data-pipeline/data/score/downloadable/cejst_technical_support_document.pdf"
+              rel="noreferrer"
+              target="_blank"
+            >
+              technical support
+            </a>
+             and other documentation and 
             <a
               class="usa-link usa-link--external"
               data-cy=""

--- a/client/src/pages/tests/__snapshots__/freqAskedQuestions.test.tsx.snap
+++ b/client/src/pages/tests/__snapshots__/freqAskedQuestions.test.tsx.snap
@@ -369,7 +369,7 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
             >
               sending feedback
             </a>
-             has been extended to May 25, 2022.
+             via the Request for Information has been extended to May 25, 2022.
           </p>
         </div>
       </div>

--- a/client/src/pages/tests/__snapshots__/freqAskedQuestions.test.tsx.snap
+++ b/client/src/pages/tests/__snapshots__/freqAskedQuestions.test.tsx.snap
@@ -320,7 +320,17 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
           <p
             class="usa-alert__text"
           >
-            Download new technical support and other documentation and 
+            Download new 
+            <a
+              class="usa-link usa-link--external"
+              data-cy=""
+              href="https://static-data-screeningtool.geoplatform.gov/data-pipeline/data/score/downloadable/cejst_technical_support_document.pdf"
+              rel="noreferrer"
+              target="_blank"
+            >
+              technical support
+            </a>
+             and other documentation and 
             <a
               class="usa-link usa-link--external"
               data-cy=""

--- a/client/src/pages/tests/__snapshots__/methodology.test.tsx.snap
+++ b/client/src/pages/tests/__snapshots__/methodology.test.tsx.snap
@@ -369,7 +369,7 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
             >
               sending feedback
             </a>
-             has been extended to May 25, 2022.
+             via the Request for Information has been extended to May 25, 2022.
           </p>
         </div>
       </div>

--- a/client/src/pages/tests/__snapshots__/methodology.test.tsx.snap
+++ b/client/src/pages/tests/__snapshots__/methodology.test.tsx.snap
@@ -320,7 +320,17 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
           <p
             class="usa-alert__text"
           >
-            Download new technical support and other documentation and 
+            Download new 
+            <a
+              class="usa-link usa-link--external"
+              data-cy=""
+              href="https://static-data-screeningtool.geoplatform.gov/data-pipeline/data/score/downloadable/cejst_technical_support_document.pdf"
+              rel="noreferrer"
+              target="_blank"
+            >
+              technical support
+            </a>
+             and other documentation and 
             <a
               class="usa-link usa-link--external"
               data-cy=""

--- a/client/src/pages/tests/__snapshots__/publicEng.test.tsx.snap
+++ b/client/src/pages/tests/__snapshots__/publicEng.test.tsx.snap
@@ -369,7 +369,7 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
             >
               sending feedback
             </a>
-             has been extended to May 25, 2022.
+             via the Request for Information has been extended to May 25, 2022.
           </p>
         </div>
       </div>
@@ -448,172 +448,15 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                 <h3
                   class="usa-collection__heading"
                 >
-                  CEJST training session #1
-                </h3>
-                <p
-                  class="usa-collection__description"
-                >
-                  
-        The White House Council on Environmental Quality (CEQ), in partnership with the U.S. Digital 
-        Service, is hosting a series of 'Training Webinars' for users of the Climate and Economic 
-        Justice Screening Tool. These webinars are an opportunity for members of the public to learn how to 
-        use the current version of the tool. The presenters at these webinars will be available to 
-        provide technical support and address issues related to accessing and using the tool.
-      
-                </p>
-                <p
-                  class="usa-collection__description"
-                >
-                  <b>
-                    Event info
-                  </b>
-                  : March 9th (4:00 - 5:00 PM EST)
-                </p>
-                <p
-                  class="usa-collection__description"
-                >
                   <a
-                    href="https://pitc.zoomgov.com/webinar/register/WN_D-Om_xXhTtiLv71y3Rr1CQ"
+                    class="usa-link usa-link--external"
+                    data-cy="may-19-reg-link-block"
+                    href="https://pitc.zoomgov.com/webinar/register/WN_1PR73vLDQpq1zoAWkhKB5g"
                     rel="noreferrer"
                     target="_blank"
                   >
-                    <button
-                      class="usa-button"
-                      data-testid="button"
-                      disabled=""
-                      type="button"
-                    >
-                      Registration link
-                    </button>
+                    CEJST listening session #4
                   </a>
-                </p>
-              </div>
-            </li>
-            <li
-              class="usa-collection__item"
-            >
-              <img
-                alt="Alt text"
-                class="usa-collection__img"
-                src="test-file-stub"
-              />
-              <div
-                class="usa-collection__body"
-              >
-                <h3
-                  class="usa-collection__heading"
-                >
-                  CEJST training session #2
-                </h3>
-                <p
-                  class="usa-collection__description"
-                >
-                  
-        The White House Council on Environmental Quality (CEQ), in partnership with the U.S. Digital 
-        Service, is hosting a series of 'Training Webinars' for users of the Climate and Economic 
-        Justice Screening Tool. These webinars are an opportunity for members of the public to learn how to 
-        use the current version of the tool. The presenters at these webinars will be available to 
-        provide technical support and address issues related to accessing and using the tool.
-      
-                </p>
-                <p
-                  class="usa-collection__description"
-                >
-                  <b>
-                    Event info
-                  </b>
-                  : March 10th (4:00 - 5:00 PM EST)
-                </p>
-                <p
-                  class="usa-collection__description"
-                >
-                  <a
-                    href="https://pitc.zoomgov.com/webinar/register/WN_QsSqshI4TpmRBkI6nVlWxQ"
-                    rel="noreferrer"
-                    target="_blank"
-                  >
-                    <button
-                      class="usa-button"
-                      data-testid="button"
-                      disabled=""
-                      type="button"
-                    >
-                      Registration link
-                    </button>
-                  </a>
-                </p>
-              </div>
-            </li>
-            <li
-              class="usa-collection__item"
-            >
-              <img
-                alt="Alt text"
-                class="usa-collection__img"
-                src="test-file-stub"
-              />
-              <div
-                class="usa-collection__body"
-              >
-                <h3
-                  class="usa-collection__heading"
-                >
-                  CEJST training session #3
-                </h3>
-                <p
-                  class="usa-collection__description"
-                >
-                  
-        The White House Council on Environmental Quality (CEQ), in partnership with the U.S. Digital 
-        Service, is hosting a series of 'Training Webinars' for users of the Climate and Economic 
-        Justice Screening Tool. These webinars are an opportunity for members of the public to learn how to 
-        use the current version of the tool. The presenters at these webinars will be available to 
-        provide technical support and address issues related to accessing and using the tool.
-      
-                </p>
-                <p
-                  class="usa-collection__description"
-                >
-                  <b>
-                    Event info
-                  </b>
-                  : March 16th (4:00 - 5:00 PM EST)
-                </p>
-                <p
-                  class="usa-collection__description"
-                >
-                  <a
-                    href="https://pitc.zoomgov.com/webinar/register/WN_q86iMtpwTESYa6f0xpIk7g"
-                    rel="noreferrer"
-                    target="_blank"
-                  >
-                    <button
-                      class="usa-button"
-                      data-testid="button"
-                      disabled=""
-                      type="button"
-                    >
-                      Registration link
-                    </button>
-                  </a>
-                </p>
-              </div>
-            </li>
-            <li
-              class="usa-collection__item"
-            >
-              <img
-                alt="Alt text"
-                class="usa-collection__img"
-                src="test-file-stub"
-              />
-              <div
-                class="usa-collection__body"
-              >
-                <h3
-                  class="usa-collection__heading"
-                >
-                  CEJST listening session #1
                 </h3>
                 <p
                   class="usa-collection__description"
@@ -632,20 +475,19 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                   <b>
                     Event info
                   </b>
-                  : March 22nd (4:00 - 5:00 PM EST)
+                  : May 19th (4:00 PM EST)
                 </p>
                 <p
                   class="usa-collection__description"
                 >
                   <a
-                    href="https://pitc.zoomgov.com/webinar/register/WN_YT7_uLZqScGHgyAcTCuJjA"
+                    href="https://pitc.zoomgov.com/webinar/register/WN_1PR73vLDQpq1zoAWkhKB5g"
                     rel="noreferrer"
                     target="_blank"
                   >
                     <button
                       class="usa-button"
                       data-testid="button"
-                      disabled=""
                       type="button"
                     >
                       Registration link
@@ -668,13 +510,17 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                 <h3
                   class="usa-collection__heading"
                 >
-                  CEJST Public WHEJAC meeting day one
+                  CEJST listening session #3
                 </h3>
                 <p
                   class="usa-collection__description"
                 >
                   
-        The White House Environmental Justice Advisory Council is also soliciting feedback on the beta version of the Climate and Economic Justice Screening Tool at its public meeting. The link above has additional details.
+        CEQ is hosting public listening sessions to seek input and feedback on the beta version of the 
+        tool, including on the datasets it includes and the methodology it uses. This feedback is critical 
+        to the development and enhancement of the tool. This feedback will help CEQ update and refine the 
+        tool to ensure that it reflects the environmental, climate and other challenges that communities 
+        are experiencing.
       
                 </p>
                 <p
@@ -683,64 +529,13 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                   <b>
                     Event info
                   </b>
-                  : March 30th (3:00 - 7:00 PM EST)
+                  : May 10th (4:00 PM EST)
                 </p>
                 <p
                   class="usa-collection__description"
                 >
                   <a
-                    href="https://usepa.zoomgov.com/webinar/register/WN_wCwVP1dtT0auAR5kfucVtw"
-                    rel="noreferrer"
-                    target="_blank"
-                  >
-                    <button
-                      class="usa-button"
-                      data-testid="button"
-                      disabled=""
-                      type="button"
-                    >
-                      Registration link
-                    </button>
-                  </a>
-                </p>
-              </div>
-            </li>
-            <li
-              class="usa-collection__item"
-            >
-              <img
-                alt="Alt text"
-                class="usa-collection__img"
-                src="test-file-stub"
-              />
-              <div
-                class="usa-collection__body"
-              >
-                <h3
-                  class="usa-collection__heading"
-                >
-                  CEJST Public WHEJAC meeting day two
-                </h3>
-                <p
-                  class="usa-collection__description"
-                >
-                  
-        The White House Environmental Justice Advisory Council is also soliciting feedback on the beta version of the Climate and Economic Justice Screening Tool at its public meeting. The link above has additional details.
-      
-                </p>
-                <p
-                  class="usa-collection__description"
-                >
-                  <b>
-                    Event info
-                  </b>
-                  : March 31th (3:00 - 7:30 PM EST)
-                </p>
-                <p
-                  class="usa-collection__description"
-                >
-                  <a
-                    href="https://usepa.zoomgov.com/webinar/register/WN_wCwVP1dtT0auAR5kfucVtw"
+                    href="https://pitc.zoomgov.com/webinar/register/WN_dt0xRNioR8SugY2hrDk1JA"
                     rel="noreferrer"
                     target="_blank"
                   >
@@ -825,17 +620,13 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                 <h3
                   class="usa-collection__heading"
                 >
-                  CEJST listening session #3
+                  CEJST Public WHEJAC meeting day two
                 </h3>
                 <p
                   class="usa-collection__description"
                 >
                   
-        CEQ is hosting public listening sessions to seek input and feedback on the beta version of the 
-        tool, including on the datasets it includes and the methodology it uses. This feedback is critical 
-        to the development and enhancement of the tool. This feedback will help CEQ update and refine the 
-        tool to ensure that it reflects the environmental, climate and other challenges that communities 
-        are experiencing.
+        The White House Environmental Justice Advisory Council is also soliciting feedback on the beta version of the Climate and Economic Justice Screening Tool at its public meeting. The link above has additional details.
       
                 </p>
                 <p
@@ -844,13 +635,13 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                   <b>
                     Event info
                   </b>
-                  : May 10th (4:00 PM EST)
+                  : March 31th (3:00 - 7:30 PM EST)
                 </p>
                 <p
                   class="usa-collection__description"
                 >
                   <a
-                    href="https://pitc.zoomgov.com/webinar/register/WN_dt0xRNioR8SugY2hrDk1JA"
+                    href="https://usepa.zoomgov.com/webinar/register/WN_wCwVP1dtT0auAR5kfucVtw"
                     rel="noreferrer"
                     target="_blank"
                   >
@@ -880,15 +671,58 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                 <h3
                   class="usa-collection__heading"
                 >
+                  CEJST Public WHEJAC meeting day one
+                </h3>
+                <p
+                  class="usa-collection__description"
+                >
+                  
+        The White House Environmental Justice Advisory Council is also soliciting feedback on the beta version of the Climate and Economic Justice Screening Tool at its public meeting. The link above has additional details.
+      
+                </p>
+                <p
+                  class="usa-collection__description"
+                >
+                  <b>
+                    Event info
+                  </b>
+                  : March 30th (3:00 - 7:00 PM EST)
+                </p>
+                <p
+                  class="usa-collection__description"
+                >
                   <a
-                    class="usa-link usa-link--external"
-                    data-cy="may-19-reg-link-block"
-                    href="https://pitc.zoomgov.com/webinar/register/WN_1PR73vLDQpq1zoAWkhKB5g"
+                    href="https://usepa.zoomgov.com/webinar/register/WN_wCwVP1dtT0auAR5kfucVtw"
                     rel="noreferrer"
                     target="_blank"
                   >
-                    CEJST listening session #4
+                    <button
+                      class="usa-button"
+                      data-testid="button"
+                      disabled=""
+                      type="button"
+                    >
+                      Registration link
+                    </button>
                   </a>
+                </p>
+              </div>
+            </li>
+            <li
+              class="usa-collection__item"
+            >
+              <img
+                alt="Alt text"
+                class="usa-collection__img"
+                src="test-file-stub"
+              />
+              <div
+                class="usa-collection__body"
+              >
+                <h3
+                  class="usa-collection__heading"
+                >
+                  CEJST listening session #1
                 </h3>
                 <p
                   class="usa-collection__description"
@@ -907,19 +741,185 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                   <b>
                     Event info
                   </b>
-                  : May 19th (4:00 PM EST)
+                  : March 22nd (4:00 - 5:00 PM EST)
                 </p>
                 <p
                   class="usa-collection__description"
                 >
                   <a
-                    href="https://pitc.zoomgov.com/webinar/register/WN_1PR73vLDQpq1zoAWkhKB5g"
+                    href="https://pitc.zoomgov.com/webinar/register/WN_YT7_uLZqScGHgyAcTCuJjA"
                     rel="noreferrer"
                     target="_blank"
                   >
                     <button
                       class="usa-button"
                       data-testid="button"
+                      disabled=""
+                      type="button"
+                    >
+                      Registration link
+                    </button>
+                  </a>
+                </p>
+              </div>
+            </li>
+            <li
+              class="usa-collection__item"
+            >
+              <img
+                alt="Alt text"
+                class="usa-collection__img"
+                src="test-file-stub"
+              />
+              <div
+                class="usa-collection__body"
+              >
+                <h3
+                  class="usa-collection__heading"
+                >
+                  CEJST training session #3
+                </h3>
+                <p
+                  class="usa-collection__description"
+                >
+                  
+        The White House Council on Environmental Quality (CEQ), in partnership with the U.S. Digital 
+        Service, is hosting a series of 'Training Webinars' for users of the Climate and Economic 
+        Justice Screening Tool. These webinars are an opportunity for members of the public to learn how to 
+        use the current version of the tool. The presenters at these webinars will be available to 
+        provide technical support and address issues related to accessing and using the tool.
+      
+                </p>
+                <p
+                  class="usa-collection__description"
+                >
+                  <b>
+                    Event info
+                  </b>
+                  : March 16th (4:00 - 5:00 PM EST)
+                </p>
+                <p
+                  class="usa-collection__description"
+                >
+                  <a
+                    href="https://pitc.zoomgov.com/webinar/register/WN_q86iMtpwTESYa6f0xpIk7g"
+                    rel="noreferrer"
+                    target="_blank"
+                  >
+                    <button
+                      class="usa-button"
+                      data-testid="button"
+                      disabled=""
+                      type="button"
+                    >
+                      Registration link
+                    </button>
+                  </a>
+                </p>
+              </div>
+            </li>
+            <li
+              class="usa-collection__item"
+            >
+              <img
+                alt="Alt text"
+                class="usa-collection__img"
+                src="test-file-stub"
+              />
+              <div
+                class="usa-collection__body"
+              >
+                <h3
+                  class="usa-collection__heading"
+                >
+                  CEJST training session #2
+                </h3>
+                <p
+                  class="usa-collection__description"
+                >
+                  
+        The White House Council on Environmental Quality (CEQ), in partnership with the U.S. Digital 
+        Service, is hosting a series of 'Training Webinars' for users of the Climate and Economic 
+        Justice Screening Tool. These webinars are an opportunity for members of the public to learn how to 
+        use the current version of the tool. The presenters at these webinars will be available to 
+        provide technical support and address issues related to accessing and using the tool.
+      
+                </p>
+                <p
+                  class="usa-collection__description"
+                >
+                  <b>
+                    Event info
+                  </b>
+                  : March 10th (4:00 - 5:00 PM EST)
+                </p>
+                <p
+                  class="usa-collection__description"
+                >
+                  <a
+                    href="https://pitc.zoomgov.com/webinar/register/WN_QsSqshI4TpmRBkI6nVlWxQ"
+                    rel="noreferrer"
+                    target="_blank"
+                  >
+                    <button
+                      class="usa-button"
+                      data-testid="button"
+                      disabled=""
+                      type="button"
+                    >
+                      Registration link
+                    </button>
+                  </a>
+                </p>
+              </div>
+            </li>
+            <li
+              class="usa-collection__item"
+            >
+              <img
+                alt="Alt text"
+                class="usa-collection__img"
+                src="test-file-stub"
+              />
+              <div
+                class="usa-collection__body"
+              >
+                <h3
+                  class="usa-collection__heading"
+                >
+                  CEJST training session #1
+                </h3>
+                <p
+                  class="usa-collection__description"
+                >
+                  
+        The White House Council on Environmental Quality (CEQ), in partnership with the U.S. Digital 
+        Service, is hosting a series of 'Training Webinars' for users of the Climate and Economic 
+        Justice Screening Tool. These webinars are an opportunity for members of the public to learn how to 
+        use the current version of the tool. The presenters at these webinars will be available to 
+        provide technical support and address issues related to accessing and using the tool.
+      
+                </p>
+                <p
+                  class="usa-collection__description"
+                >
+                  <b>
+                    Event info
+                  </b>
+                  : March 9th (4:00 - 5:00 PM EST)
+                </p>
+                <p
+                  class="usa-collection__description"
+                >
+                  <a
+                    href="https://pitc.zoomgov.com/webinar/register/WN_D-Om_xXhTtiLv71y3Rr1CQ"
+                    rel="noreferrer"
+                    target="_blank"
+                  >
+                    <button
+                      class="usa-button"
+                      data-testid="button"
+                      disabled=""
                       type="button"
                     >
                       Registration link

--- a/client/src/pages/tests/__snapshots__/publicEng.test.tsx.snap
+++ b/client/src/pages/tests/__snapshots__/publicEng.test.tsx.snap
@@ -320,7 +320,17 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
           <p
             class="usa-alert__text"
           >
-            Download new technical support and other documentation and 
+            Download new 
+            <a
+              class="usa-link usa-link--external"
+              data-cy=""
+              href="https://static-data-screeningtool.geoplatform.gov/data-pipeline/data/score/downloadable/cejst_technical_support_document.pdf"
+              rel="noreferrer"
+              target="_blank"
+            >
+              technical support
+            </a>
+             and other documentation and 
             <a
               class="usa-link usa-link--external"
               data-cy=""
@@ -815,15 +825,7 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                 <h3
                   class="usa-collection__heading"
                 >
-                  <a
-                    class="usa-link usa-link--external"
-                    data-cy="may-10-reg-link-block"
-                    href="https://pitc.zoomgov.com/webinar/register/WN_dt0xRNioR8SugY2hrDk1JA"
-                    rel="noreferrer"
-                    target="_blank"
-                  >
-                    CEJST listening session #3
-                  </a>
+                  CEJST listening session #3
                 </h3>
                 <p
                   class="usa-collection__description"
@@ -855,6 +857,7 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                     <button
                       class="usa-button"
                       data-testid="button"
+                      disabled=""
                       type="button"
                     >
                       Registration link

--- a/client/src/pages/tests/__snapshots__/publicEng.test.tsx.snap
+++ b/client/src/pages/tests/__snapshots__/publicEng.test.tsx.snap
@@ -971,6 +971,26 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                     </div>
                   </button>
                 </a>
+                <a
+                  download=""
+                  href="https://static-data-screeningtool.geoplatform.gov/data-pipeline/data/score/downloadable/technical-training-slides.pptx"
+                >
+                  <button
+                    class="usa-button"
+                    data-testid="button"
+                    type="button"
+                  >
+                    <div>
+                      <div>
+                        Download slide deck
+                      </div>
+                      <img
+                        alt="the icon to show that this button will download the file"
+                        src="test-file-stub"
+                      />
+                    </div>
+                  </button>
+                </a>
               </div>
             </div>
           </div>

--- a/client/src/pages/tests/__snapshots__/techSupportDoc.test.tsx.snap
+++ b/client/src/pages/tests/__snapshots__/techSupportDoc.test.tsx.snap
@@ -369,7 +369,7 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
             >
               sending feedback
             </a>
-             has been extended to May 25, 2022.
+             via the Request for Information has been extended to May 25, 2022.
           </p>
         </div>
       </div>

--- a/client/src/pages/tests/__snapshots__/techSupportDoc.test.tsx.snap
+++ b/client/src/pages/tests/__snapshots__/techSupportDoc.test.tsx.snap
@@ -320,7 +320,17 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
           <p
             class="usa-alert__text"
           >
-            Download new technical support and other documentation and 
+            Download new 
+            <a
+              class="usa-link usa-link--external"
+              data-cy=""
+              href="https://static-data-screeningtool.geoplatform.gov/data-pipeline/data/score/downloadable/cejst_technical_support_document.pdf"
+              rel="noreferrer"
+              target="_blank"
+            >
+              technical support
+            </a>
+             and other documentation and 
             <a
               class="usa-link usa-link--external"
               data-cy=""


### PR DESCRIPTION
# Purpose
- closes #1602 
- closes #1595 
- closes #1593
- reverses the events in the PEC

## QA 

### QA link [here](http://usds-geoplatform-justice40-website.s3-website-us-east-1.amazonaws.com/justice40-tool/1633-5245a0/en/#3/33.47/-97.5)

### QA spec
- [x] has the RFI text been added to the alert correctly?
- [x] does button download the slides correctly (under Youtube video link)
- [x] is the TSD linked correctly in the alert?
- [x] do the events load in reverse order starting with the most recent event at the top of the list?