### PR TITLE
Fix typos found in en.json files and copy

### DIFF
--- a/client/compiled-lang/en.json
+++ b/client/compiled-lang/en.json
@@ -1764,7 +1764,7 @@
   "indicator.categories.clean.water.title": [
     {
       "type": 0,
-      "value": "Critical clean water and wasterwater infrastructure"
+      "value": "Critical clean water and wastewater infrastructure"
     }
   ],
   "indicator.categories.health.burdens.title": [

--- a/client/src/components/DatasetCard/tests/__snapshots__/datasetCard.test.tsx.snap
+++ b/client/src/components/DatasetCard/tests/__snapshots__/datasetCard.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`rendering of indicator dataset card checks if component renders 1`] = `
         <span>
           Used in: 
         </span>
-        All categories except for the training and workforce development catetory
+        All categories except for the training and workforce development category
       </li>
       <li>
         <span>

--- a/client/src/components/DatasetContainer/tests/__snapshots__/datasetContainer.test.tsx.snap
+++ b/client/src/components/DatasetContainer/tests/__snapshots__/datasetContainer.test.tsx.snap
@@ -66,7 +66,7 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                   <span>
                     Used in: 
                   </span>
-                  All categories except for the training and workforce development catetory
+                  All categories except for the training and workforce development category
                 </li>
                 <li>
                   <span>

--- a/client/src/components/Indicator/Indicator.tsx
+++ b/client/src/components/Indicator/Indicator.tsx
@@ -133,7 +133,7 @@ export const IndicatorValue = ({isPercent, displayStat}:IIndicatorValue) => {
       {
         id: 'explore.tool.page.side.panel.indicator.percentile.value.ordinal.suffix',
         // eslint-disable-next-line max-len
-        description: `Navigate to the explore the tool page. Click on the map. The side panel will show categories. Open a category. This will define the indicator value's oridinal suffix. For example the st in 91st, the rd in 23rd, and the th in 26th, etc.`,
+        description: `Navigate to the explore the tool page. Click on the map. The side panel will show categories. Open a category. This will define the indicator value's ordinal suffix. For example the st in 91st, the rd in 23rd, and the th in 26th, etc.`,
         defaultMessage: `
         {indicatorValue, selectordinal, 
           one {#st} 

--- a/client/src/components/J40Footer/__snapshots__/J40Footer.spec.tsx.snap
+++ b/client/src/components/J40Footer/__snapshots__/J40Footer.spec.tsx.snap
@@ -82,7 +82,7 @@ exports[`J40Footer renders correctly 1`] = `
                     class="footer-link-first-child"
                     href="/en/public-engagement"
                   >
-                    Engagement calender
+                    Engagement calendar
                   </a>
                 </li>
                 <li
@@ -90,12 +90,12 @@ exports[`J40Footer renders correctly 1`] = `
                 >
                   <a
                     class="usa-link usa-link--external"
-                    data-cy="request-for-infomation"
+                    data-cy="request-for-information"
                     href="https://www.federalregister.gov/d/2022-03920"
                     rel="noreferrer"
                     target="_blank"
                   >
-                    Request for Infomation
+                    Request for Information
                   </a>
                 </li>
                 <li

--- a/client/src/components/SidePanelInfo/__snapshots__/SidePanelInfo.test.tsx.snap
+++ b/client/src/components/SidePanelInfo/__snapshots__/SidePanelInfo.test.tsx.snap
@@ -24,7 +24,7 @@ exports[`rendering of the component expects the render to match snapshot 1`] = `
     </p>
     <img
       alt="
-      An icon that has depicts pieces of a block selected mimicing the census block census tracts
+      An icon that has depicts pieces of a block selected mimicking the census block census tracts
     "
       src="test-file-stub"
       tabindex="0"

--- a/client/src/components/__snapshots__/mapInfoPanel.test.tsx.snap
+++ b/client/src/components/__snapshots__/mapInfoPanel.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`simulate app starting up, no click on map should match the snapshot of 
       </p>
       <img
         alt="
-      An icon that has depicts pieces of a block selected mimicing the census block census tracts
+      An icon that has depicts pieces of a block selected mimicking the census block census tracts
     "
         src="test-file-stub"
         tabindex="0"

--- a/client/src/data/copy/common.tsx
+++ b/client/src/data/copy/common.tsx
@@ -167,12 +167,12 @@ export const FOOTER = defineMessages({
   },
   ENG_CAL: {
     id: 'common.pages.footer.eng.cal.text',
-    defaultMessage: 'Engagement calender',
+    defaultMessage: 'Engagement calendar',
     description: 'Navigate to the about page. This is Footer eng.cal.gov link text',
   },
   RFI: {
     id: 'common.pages.footer.rfi.text',
-    defaultMessage: 'Request for Infomation',
+    defaultMessage: 'Request for Information',
     description: 'Navigate to the about page. This is Footer rfi link text',
   },
   RFI_LINK: {

--- a/client/src/data/copy/downloads.tsx
+++ b/client/src/data/copy/downloads.tsx
@@ -8,22 +8,22 @@ export const PAGE_INTRO = defineMessages({
   PAGE_TILE: {
     id: 'downloads.page.title.text',
     defaultMessage: 'Downloads',
-    description: 'Navigate to the the Downloads page, this will be the page title text',
+    description: 'Navigate to the Downloads page, this will be the page title text',
   },
   PAGE_HEADING1: {
     id: 'downloads.page.heading1.text',
     defaultMessage: 'Downloads',
-    description: 'Navigate to the the Downloads page, this will be the page heading1 text',
+    description: 'Navigate to the Downloads page, this will be the page heading1 text',
   },
   PAGE_HEADING2: {
     id: 'downloads.page.heading2.text',
     defaultMessage: 'File formats',
-    description: 'Navigate to the the Downloads page, this will be the page heading2 text',
+    description: 'Navigate to the Downloads page, this will be the page heading2 text',
   },
   PAGE_DESCRIPTION1: {
     id: 'downloads.page.description1.text',
     defaultMessage: 'The dataset used in the tool, along with a data dictionary and information about how to use the list of communities (.pdf) are available in the following file formats:',
-    description: 'Navigate to the the Downloads page, this will be the page description1 text',
+    description: 'Navigate to the Downloads page, this will be the page description1 text',
   },
 });
 

--- a/client/src/data/copy/explore.tsx
+++ b/client/src/data/copy/explore.tsx
@@ -27,7 +27,7 @@ export const PAGE_DESCRIPTION = <FormattedMessage
   defaultMessage={`
     Use the map to see communities that are identified as disadvantaged. The map uses 
     publicly-available, nationally-consistent datasets. Learn more about 
-    the methodology and datasets that were used to identify disavantaged communities
+    the methodology and datasets that were used to identify disadvantaged communities
     in the current version of the map on the <link1>Methodology & data</link1> page.
     `}
   description={'On the explore the map page, the description of the page'}
@@ -126,12 +126,12 @@ export const MAP = defineMessages({
   AS_SHORT: {
     id: 'explore.map.page.map.territoryFocus.american.samoa.short',
     defaultMessage: 'AS',
-    description: `On the explore the map page, on the map, the abbreviated name indicating the bounds of American Somoa`,
+    description: `On the explore the map page, on the map, the abbreviated name indicating the bounds of American Samoa`,
   },
   AS_LONG: {
     id: 'explore.map.page.map.territoryFocus.american.samoa.long',
     defaultMessage: 'American Samoa',
-    description: 'On the explore the map page, on the map, the full name indicating the bounds of American Somoa',
+    description: 'On the explore the map page, on the map, the full name indicating the bounds of American Samoa',
   },
   MP_SHORT: {
     id: 'explore.map.page.map.territoryFocus.commonwealth.nmp.short',
@@ -201,7 +201,7 @@ export const SIDE_PANEL_INITIAL_STATE = defineMessages({
   ALT_TEXT_ICON1: {
     id: 'explore.map.page.side.panel.info.alt.text.icon1',
     defaultMessage: `
-      An icon that has depicts pieces of a block selected mimicing the census block census tracts
+      An icon that has depicts pieces of a block selected mimicking the census block census tracts
     `,
     description: `Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show Things to know, this is the first icon in this side panel`,
   },
@@ -233,7 +233,7 @@ export const SIDE_PANEL_INITIAL_STATE_PARA5 = <FormattedMessage
   defaultMessage={ `
     Thresholds for each category determine if a tract should be identified as disadvantaged because it has exceeded a certain value for the relevant indicators.
   `}
-  description={`Navigate to the explore the map page. When the map is in view, click on the map. The side panelwill show Things to know, this is the fifth paragraph of this side pane`}
+  description={`Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show Things to know, this is the fifth paragraph of this side pane`}
 />;
 
 export const SIDE_PANEL_VERION = {
@@ -578,7 +578,7 @@ export const SIDE_PANEL_INDICATOR_DESCRIPTION = defineMessages({
   EXP_AG_LOSS: {
     id: 'explore.map.page.side.panel.indicator.description.exp.ag.loss',
     defaultMessage: 'Economic loss rate to agricultural value resulting from natural hazards each year',
-    description: `Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator desciption of Economic loss rate to agriculture resulting from naturhazards
+    description: `Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator description of Economic loss rate to agriculture resulting from natural hazards
     `,
 
   },
@@ -586,14 +586,14 @@ export const SIDE_PANEL_INDICATOR_DESCRIPTION = defineMessages({
     id: 'explore.map.page.side.panel.indicator.description.exp.bld.loss',
     defaultMessage: 'Economic loss rate to agricultural value resulting from natural hazards each year',
     description: `Navigate to the explore the map page. When the map is in view, click on the map. The side 
-    panel will show an indicator desciption of Economic loss rate to buildings resulting from natural hazards`,
+    panel will show an indicator description of Economic loss rate to buildings resulting from natural hazards`,
   },
   EXP_POP_LOSS: {
     id: 'explore.map.page.side.panel.indicator.description.exp.pop.loss',
     defaultMessage: `
       Rate of fatalities and injuries resulting from natural hazards each year
     `,
-    description: `Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator desciption of Economic loss rate to the population in fatalities and 
+    description: `Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator description of Economic loss rate to the population in fatalities and 
       injuries resulting from natural hazards`,
   },
   LOW_INCOME: {
@@ -601,7 +601,7 @@ export const SIDE_PANEL_INDICATOR_DESCRIPTION = defineMessages({
     defaultMessage: `
       Household income is less than or equal to twice the federal poverty level 
     `,
-    description: `Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator desciption of Household income is less than or equal to twice the federal poverty level`,
+    description: `Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator description of Household income is less than or equal to twice the federal poverty level`,
   },
   HIGH_ED: {
     id: 'explore.map.page.side.panel.indicator.description.high.ed',
@@ -609,29 +609,29 @@ export const SIDE_PANEL_INDICATOR_DESCRIPTION = defineMessages({
       Percent of the census tract's population 15 or older not enrolled in college, university, or 
       graduate school 
     `,
-    description: `Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator desciption of Percent of the census tract's population 15 or older not 
+    description: `Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator description of Percent of the census tract's population 15 or older not 
       enrolled in college, university, or graduate school`,
   },
   ENERGY_BURDEN: {
     id: 'explore.map.page.side.panel.indicator.description.energyBurden',
     defaultMessage: 'Average annual energy costs divided by household income',
-    description: `Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator desciption of Energy costs divided by household income`,
+    description: `Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator description of Energy costs divided by household income`,
   },
   PM_2_5: {
     id: 'explore.map.page.side.panel.indicator.description.pm25',
     defaultMessage: 'Fine inhalable particles, 2.5 micrometers or smaller',
-    description: `Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator desciption of Fine inhalable particles, 2.5 micrometers and smaller`,
+    description: `Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator description of Fine inhalable particles, 2.5 micrometers and smaller`,
   },
 
   DIESEL_PARTICULATE_MATTER: {
     id: 'explore.map.page.side.panel.indicator.description.dieselPartMatter',
     defaultMessage: 'Diesel exhaust in the air',
-    description: `Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator desciption of Diesel exhaust in the air`,
+    description: `Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator description of Diesel exhaust in the air`,
   },
   TRAFFIC_VOLUME: {
     id: 'explore.map.page.side.panel.indicator.description.trafficVolume',
     defaultMessage: 'Count of vehicles at major roads within 500 meters',
-    description: `Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator desciption of Count of vehicles at major roads within 500 meters`,
+    description: `Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator description of Count of vehicles at major roads within 500 meters`,
   },
 
   LEAD_PAINT: {
@@ -639,47 +639,47 @@ export const SIDE_PANEL_INDICATOR_DESCRIPTION = defineMessages({
     defaultMessage: `
       Percentile of number of homes built before 1960 that are not among the most expensive
     `,
-    description: `Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator desciption of Pre-1960 housing`,
+    description: `Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator description of Pre-1960 housing`,
   },
   MED_HOME_VAL: {
     id: 'explore.map.page.side.panel.indicator.description.med.home.val',
     defaultMessage: 'Median home value in area',
-    description: `Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator desciption of Meidan home value in area`,
+    description: `Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator description of Median home value in area`,
 
   },
   HOUSE_BURDEN: {
     id: 'explore.map.page.side.panel.indicator.description.houseBurden',
     defaultMessage: 'Low income households spending more than 30% of income on housing',
-    description: `Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator desciption of Low income households spending more than 30% of income housing
+    description: `Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator description of Low income households spending more than 30% of income housing
     `,
   },
 
   PROX_HAZ: {
     id: 'explore.map.page.side.panel.indicator.description.prox.haz',
     defaultMessage: 'Count of hazardous waste facilities within 5 kilometers',
-    description: `Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator desciption of Count of hazardous waste facilities within 5 kilometers`,
+    description: `Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator description of Count of hazardous waste facilities within 5 kilometers`,
   },
   PROX_NPL: {
     id: 'explore.map.page.side.panel.indicator.description.prox.npl',
     defaultMessage: 'Proposed or listed NPL (Superfund) sites within 5 kilometers',
-    description: `Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator desciption of Proposed or listed NPL (Superfund) sites within 5 kilometers`,
+    description: `Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator description of Proposed or listed NPL (Superfund) sites within 5 kilometers`,
   },
   PROX_RMP: {
     id: 'explore.map.page.side.panel.indicator.description.prox.rmp',
     defaultMessage: 'RMP facilities within 5 kilometers',
-    description: `Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator desciption of Risk Management Plan facilities within 5 kilometers`,
+    description: `Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator description of Risk Management Plan facilities within 5 kilometers`,
   },
 
   WASTE_WATER: {
     id: 'explore.map.page.side.panel.indicator.description.wasteWater',
     defaultMessage: 'Toxic concentrations at stream segments within 500 meters',
-    description: `Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator desciption of Toxic concentrations at stream segments within 500 meters`,
+    description: `Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator description of Toxic concentrations at stream segments within 500 meters`,
   },
 
   ASTHMA: {
     id: 'explore.map.page.side.panel.indicator.description.asthma',
     defaultMessage: 'Weighted percent of people who have been told they have asthma',
-    description: `Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator desciption of Number of people who have been told they have asthma`,
+    description: `Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator description of Number of people who have been told they have asthma`,
   },
   DIABETES: {
     id: 'explore.map.page.side.panel.indicator.description.diabetes',
@@ -687,38 +687,38 @@ export const SIDE_PANEL_INDICATOR_DESCRIPTION = defineMessages({
       Weighted percent of people ages 18 years and older who have diabetes other than 
       diabetes during pregnancy
     `,
-    description: `Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator desciption of People ages 18 years and older who have diabetes other than 
+    description: `Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator description of People ages 18 years and older who have diabetes other than 
       diabetes during pregnancy`,
   },
   HEART_DISEASE: {
     id: 'explore.map.page.side.panel.indicator.description.heartDisease',
     defaultMessage: `People ages 18 years and older who have been told they have heart disease`,
-    description: `Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator desciption of Weighted percent of people ages 18 years and older who have 
+    description: `Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator description of Weighted percent of people ages 18 years and older who have 
     been told they have heart disease`,
   },
   LOW_LIFE_EXPECT: {
     id: 'explore.map.page.side.panel.indicator.description.lifeExpect',
     defaultMessage: 'Average number of years a person can expect to live',
-    description: `Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator desciption of Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator desciption of Average number of years of life a person can expect to live`,
+    description: `Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator description of Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator description of Average number of years of life a person can expect to live`,
   },
 
   LOW_MED_INCOME: {
     id: 'explore.map.page.side.panel.indicator.description.low.med.income',
     defaultMessage: 'Median income calculated as a percent of the area’s median income',
-    description: `Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator desciption of Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator desciption of Median income calculated as a percent of the area’s median income`,
+    description: `Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator description of Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator description of Median income calculated as a percent of the area’s median income`,
   },
   LING_ISO: {
     id: 'explore.map.page.side.panel.indicator.description.ling.iso',
     defaultMessage: `
       Percent of households where no one over the age 14 speaks English well
     `,
-    description: `Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator desciption of Households in which no one age 14 and over speaks English only or also speaks a language other than English`,
+    description: `Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator description of Households in which no one age 14 and over speaks English only or also speaks a language other than English`,
   },
   UNEMPLOY: {
     id: 'explore.map.page.side.panel.indicator.description.unemploy',
     defaultMessage: 'Number of unemployed people as a percentage of the labor force',
     description: `Navigate to the explore the map page. When the map is in view, click on the map. The side 
-    panel will show an indicator desciption of Number of unemployed people as a percentage of the labor force`,
+    panel will show an indicator description of Number of unemployed people as a percentage of the labor force`,
   },
   POVERTY: {
     id: 'explore.map.page.side.panel.indicator.description.poverty',
@@ -726,14 +726,14 @@ export const SIDE_PANEL_INDICATOR_DESCRIPTION = defineMessages({
       Percent of a census tract's population in households where the household income is at or below 100% 
       of the Federal poverty level 
     `,
-    description: `Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator desciption of Percent of individuals in households where the household income is at or below 100% of the federal poverty level`,
+    description: `Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator description of Percent of individuals in households where the household income is at or below 100% of the federal poverty level`,
   },
   HIGH_SKL: {
     id: 'explore.map.page.side.panel.indicator.description.high.school',
     defaultMessage: `
       Percent of people ages 25 years or older whose education level is less than a high school diploma 
     `,
-    description: `Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator desciption of Percent of people ages 25 years or older whose education level 
+    description: `Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator description of Percent of people ages 25 years or older whose education level 
       is less than a high school diploma`,
   },
 });
@@ -858,7 +858,7 @@ export const NOTE_ON_TRIBAL_NATIONS = {
       to provide Tribal Nations with meaningful opportunities for input, consistent with CEQ’s <link2>
       Action Plan for Consultation and Coordination with Tribal Nations</link2>,
       <link3>President Biden’s Memorandum on Tribal Consultation and Strengthening 
-      Nation-to-Nation Consultation</link3>, and Executive Order 13175 on <link4>Consulation and 
+      Nation-to-Nation Consultation</link3>, and Executive Order 13175 on <link4>Consultation and 
       Coordination With Indian Tribal Governments</link4>.
     `}
     description={`Navigate to the explore the map page. Under the map, you will see tribal nations paragraph 1`}

--- a/client/src/data/copy/faqs.tsx
+++ b/client/src/data/copy/faqs.tsx
@@ -6,11 +6,11 @@ export const PAGE_INTRO = defineMessages({
   PAGE_TILE: {
     id: 'faqs.page.title.text',
     defaultMessage: 'Frequently asked questions',
-    description: 'Navigate to the the FAQs page, this will be the page title text',
+    description: 'Navigate to the FAQs page, this will be the page title text',
   },
   COMING_SOON: {
     id: 'faqs.page.coming.soon.text',
     defaultMessage: 'Coming Soon!',
-    description: 'Navigate to the the FAQs page, this will be the page coming soon text',
+    description: 'Navigate to the FAQs page, this will be the page coming soon text',
   },
 });

--- a/client/src/data/copy/methodology.tsx
+++ b/client/src/data/copy/methodology.tsx
@@ -263,7 +263,7 @@ export const CATEGORIES = {
   />,
   ALL_EXCEPT_WORKFORCE: <FormattedMessage
     id={'methodology.page.datasets.all.except.workforce.used.in.text'}
-    defaultMessage={`All categories except for the training and workforce development catetory`}
+    defaultMessage={`All categories except for the training and workforce development category`}
     description={'Navigate to the methodology page. Navigate to the dataset section. This is the portion of the dataset card Used In text for all methodologies except the workforce development'}
   />,
   CLIMATE_CHANGE: {
@@ -687,17 +687,17 @@ export const AVAILABLE_FOR = defineMessages({
   ALL_US_DC: {
     id: 'methodology.page.dataset.card.availableFor.US_DC',
     defaultMessage: `All U.S. states and the District of Columbia`,
-    description: 'Methodoloy page dataset card available for US and DC type',
+    description: 'Methodology page dataset card available for US and DC type',
   },
   ALL_US_DC_PR: {
     id: 'methodology.page.dataset.card.availableFor.US_DC_PR',
     defaultMessage: `All U.S. states, the District of Columbia, and Puerto Rico`,
-    description: 'Methodoloy page dataset card available for US, DC and Puerto Rico type',
+    description: 'Methodology page dataset card available for US, DC and Puerto Rico type',
   },
   AS_NMI: {
     id: 'methodology.page.dataset.card.availableFor.AS_NMI',
     defaultMessage: `American Samoa and the Northern Mariana Islands`,
-    description: 'Methodoloy page dataset card available for American Samoa and Northern Mariana Islands type',
+    description: 'Methodology page dataset card available for American Samoa and Northern Mariana Islands type',
   },
 });
 

--- a/client/src/data/copy/publicEngage.tsx
+++ b/client/src/data/copy/publicEngage.tsx
@@ -24,17 +24,17 @@ export const PAGE_INTRO = defineMessages({
   PAGE_TILE: {
     id: 'public.eng.page.title.text',
     defaultMessage: 'Public engagement opportunities',
-    description: 'Navigate to the the public engagement page, this will be the publiceng page title text',
+    description: 'Navigate to the public engagement page, this will be the publiceng page title text',
   },
   PAGE_HEADING1: {
     id: 'public.eng.page.heading1.text',
     defaultMessage: 'Public engagement opportunities',
-    description: 'Navigate to the the public engagement page, this will be the publiceng page header text',
+    description: 'Navigate to the public engagement page, this will be the publiceng page header text',
   },
   PAGE_HEADING2: {
     id: 'public.eng.page.sub.header2.text',
     defaultMessage: 'Find an event',
-    description: 'Navigate to the the public engagement page, this will be the publiceng page sub header text',
+    description: 'Navigate to the public engagement page, this will be the publiceng page sub header text',
   },
   PAGE_DESCRIPTION1: {
     id: 'public.eng.page.description1.text',
@@ -44,14 +44,14 @@ export const PAGE_INTRO = defineMessages({
       beta version of the tool. CEQ hopes that members of the public will join these engagements to learn 
       about the tool, have their questions answered, and share feedback.
     `,
-    description: 'Navigate to the the public engagement page, this will be the publiceng page description 1 text',
+    description: 'Navigate to the public engagement page, this will be the publiceng page description 1 text',
   },
   PAGE_DESCRIPTION2: {
     id: 'public.eng.page.description2.text',
     defaultMessage: `
       Pre-registration is required to participate and speak at the sessions.
     `,
-    description: 'Navigate to the the public engagement page, this will be the publiceng page description 2 text',
+    description: 'Navigate to the public engagement page, this will be the publiceng page description 2 text',
   },
   PAGE_DESCRIPTION3: {
     id: 'public.eng.page.description3.text',
@@ -59,12 +59,12 @@ export const PAGE_INTRO = defineMessages({
       As they become available, additional public trainings and engagement opportunities on the Climate 
       and Economic Justice Screening Tool will also be posted on this page.
     `,
-    description: 'Navigate to the the public engagement page, this will be the publiceng page description 3 text',
+    description: 'Navigate to the public engagement page, this will be the publiceng page description 3 text',
   },
   SURVEY_TEXT: {
     id: 'fab.survey.text',
     defaultMessage: `Help improve the site & data`,
-    description: 'Navigate to the the public engagement page, this will be the text for floating action button',
+    description: 'Navigate to the public engagement page, this will be the text for floating action button',
   },
 });
 
@@ -72,32 +72,32 @@ export const PUBLIC_ENG_VIDEO = defineMessages({
   TITLE: {
     id: 'public.eng.page.video.box.title.text',
     defaultMessage: `Can't make an upcoming session?`,
-    description: 'Navigate to the the public engagement page, there will be box that allows users to watch previously recorded videos. This is that box title text.',
+    description: 'Navigate to the public engagement page, there will be box that allows users to watch previously recorded videos. This is that box title text.',
   },
   BODY: {
     id: 'public.eng.page.video.box.body.text',
     defaultMessage: `Watch a recorded version of the CEJST training on YouTube.`,
-    description: 'Navigate to the the public engagement page, there will be box that allows users to watch previously recorded videos. This is that box body text.',
+    description: 'Navigate to the public engagement page, there will be box that allows users to watch previously recorded videos. This is that box body text.',
   },
   BUTTON1_TEXT: {
     id: 'public.eng.page.video.box.button1.text',
     defaultMessage: `Watch on YouTube`,
-    description: 'Navigate to the the public engagement page, there will be box that allows users to watch previously recorded videos. This is that box button text.',
+    description: 'Navigate to the public engagement page, there will be box that allows users to watch previously recorded videos. This is that box button text.',
   },
   IMG_ALT_TEXT1: {
     id: 'public.eng.page.video.box.button.img.alt.text1',
     defaultMessage: `the icon to show that this button will open in a new tab`,
-    description: 'Navigate to the the public engagement page, there will be box that allows users to watch previously recorded videos. This is alt tag of the image in the button.',
+    description: 'Navigate to the public engagement page, there will be box that allows users to watch previously recorded videos. This is alt tag of the image in the button.',
   },
   BUTTON2_TEXT: {
     id: 'public.eng.page.video.box.button2.text',
     defaultMessage: `Download slide deck`,
-    description: 'Navigate to the the public engagement page, there will be box that allows users to watch previously recorded videos. This is the button text for the second button.',
+    description: 'Navigate to the public engagement page, there will be box that allows users to watch previously recorded videos. This is the button text for the second button.',
   },
   IMG_ALT_TEXT2: {
     id: 'public.eng.page.video.box.button.img.alt.text2',
     defaultMessage: `the icon to show that this button will download the file`,
-    description: 'Navigate to the the public engagement page, there will be box that allows users to watch previously recorded videos. This is alt tag of the image in the 2nd button.',
+    description: 'Navigate to the public engagement page, there will be box that allows users to watch previously recorded videos. This is alt tag of the image in the 2nd button.',
   },
 });
 
@@ -105,17 +105,17 @@ export const PUBLIC_ENG_BUTTON = defineMessages({
   LABEL: {
     id: 'public.eng.page.button.label',
     defaultMessage: `Public engagement`,
-    description: 'Navigate to the the public engagement page, this will be the public engagement button label',
+    description: 'Navigate to the public engagement page, this will be the public engagement button label',
   },
   TAG_LABEL: {
     id: 'public.eng.page.tag.label',
     defaultMessage: `UPDATED`,
-    description: 'Navigate to the the public engagement page, this will be the public engagement tag label',
+    description: 'Navigate to the public engagement page, this will be the public engagement tag label',
   },
   IMG_ICON_ALT_TAG: {
     id: 'public.eng.page.button.img.alt.tag',
     defaultMessage: `an icon that represents a calendar`,
-    description: 'Navigate to the the public engagement page, this will be the public engagement button icon alt tag text',
+    description: 'Navigate to the public engagement page, this will be the public engagement button icon alt tag text',
   },
 });
 
@@ -124,7 +124,7 @@ export const EVENT_TYPES = {
     NAME: {
       id: 'public.eng.page.event.training.sess.name',
       defaultMessage: `training session`,
-      description: 'Navigate to the the public engagement page, this will be the public engagement page event training session name',
+      description: 'Navigate to the public engagement page, this will be the public engagement page event training session name',
     },
     DESCRIPTION: {
       id: 'public.eng.page.event.training.description',
@@ -135,14 +135,14 @@ export const EVENT_TYPES = {
         use the current version of the tool. The presenters at these webinars will be available to 
         provide technical support and address issues related to accessing and using the tool.
       `,
-      description: 'Navigate to the the public engagement page, this will be the public engagement page event training session description',
+      description: 'Navigate to the public engagement page, this will be the public engagement page event training session description',
     },
   }),
   LISTENING_SESS: defineMessages({
     NAME: {
       id: 'public.eng.page.event.listening.sess.name',
       defaultMessage: `listening session`,
-      description: 'Navigate to the the public engagement page, this will be the public engagement page event listening session name',
+      description: 'Navigate to the public engagement page, this will be the public engagement page event listening session name',
     },
     DESCRIPTION: {
       id: 'public.eng.page.event.listening.sess.description',
@@ -153,7 +153,7 @@ export const EVENT_TYPES = {
         tool to ensure that it reflects the environmental, climate and other challenges that communities 
         are experiencing.
       `,
-      description: 'Navigate to the the public engagement page, this will be the public engagement page event listening session description',
+      description: 'Navigate to the public engagement page, this will be the public engagement page event listening session description',
     },
   }),
   WHEJAC_DAY1: defineMessages({
@@ -190,12 +190,12 @@ export const EVENT_FIELDS = defineMessages({
   EVENT_INFO: {
     id: 'public.eng.page.event.info.label',
     defaultMessage: 'Event info',
-    description: 'Navigate to the the public engagement page, this will be the public engagement page event info label',
+    description: 'Navigate to the public engagement page, this will be the public engagement page event info label',
   },
   REG_LINK: {
     id: 'public.eng.page.event.reglink.label',
     defaultMessage: 'Registration link',
-    description: 'Navigate to the the public engagement page, this will be the public engagment page event registration link label',
+    description: 'Navigate to the public engagement page, this will be the public engagement page event registration link label',
   },
 });
 
@@ -213,7 +213,7 @@ export const EVENTS = [
       INFO: {
         id: 'public.eng.page.event.training.1.info',
         defaultMessage: `March 9th (4:00 - 5:00 PM EST)`,
-        description: 'Navigate to the the public engagement page, this will be the public engagement page event training session 1 date',
+        description: 'Navigate to the public engagement page, this will be the public engagement page event training session 1 date',
       },
     }),
     REG_LINK: `https://pitc.zoomgov.com/webinar/register/WN_D-Om_xXhTtiLv71y3Rr1CQ`,
@@ -230,7 +230,7 @@ export const EVENTS = [
       INFO: {
         id: 'public.eng.page.event.training.2.info',
         defaultMessage: `March 10th (4:00 - 5:00 PM EST)`,
-        description: 'Navigate to the the public engagement page, this will be the public engagement page event training session 2 date',
+        description: 'Navigate to the public engagement page, this will be the public engagement page event training session 2 date',
       },
     }),
     REG_LINK: `https://pitc.zoomgov.com/webinar/register/WN_QsSqshI4TpmRBkI6nVlWxQ`,
@@ -248,7 +248,7 @@ export const EVENTS = [
       INFO: {
         id: 'public.eng.page.event.training.3.info',
         defaultMessage: `March 16th (4:00 - 5:00 PM EST)`,
-        description: 'Navigate to the the public engagement page, this will be the public engagement page event training session 3 date',
+        description: 'Navigate to the public engagement page, this will be the public engagement page event training session 3 date',
       },
     }),
     REG_LINK: `https://pitc.zoomgov.com/webinar/register/WN_q86iMtpwTESYa6f0xpIk7g`,
@@ -266,7 +266,7 @@ export const EVENTS = [
       INFO: {
         id: 'public.eng.page.event.listening.1.info',
         defaultMessage: `March 22nd (4:00 - 5:00 PM EST)`,
-        description: 'Navigate to the the public engagement page, this will be the public engagement page event listening session 1 date',
+        description: 'Navigate to the public engagement page, this will be the public engagement page event listening session 1 date',
       },
     }),
     REG_LINK: `https://pitc.zoomgov.com/webinar/register/WN_YT7_uLZqScGHgyAcTCuJjA`,
@@ -318,7 +318,7 @@ export const EVENTS = [
       INFO: {
         id: 'public.eng.page.event.listening.2.info',
         defaultMessage: `April 15th (4:00 - 5:00 PM EST)`,
-        description: 'Navigate to the the public engagement page, this will be the public engagement page event listening session 2 date',
+        description: 'Navigate to the public engagement page, this will be the public engagement page event listening session 2 date',
       },
     }),
     REG_LINK: `https://pitc.zoomgov.com/webinar/register/WN_dLw3xChiTlaOLGdHXQWk0w`,
@@ -335,7 +335,7 @@ export const EVENTS = [
       INFO: {
         id: 'public.eng.page.event.listening.3.info',
         defaultMessage: `May 10th (4:00 PM EST)`,
-        description: 'Navigate to the the public engagement page, this will be the public engagement page event listening session 3 date',
+        description: 'Navigate to the public engagement page, this will be the public engagement page event listening session 3 date',
       },
     }),
     REG_LINK: `https://pitc.zoomgov.com/webinar/register/WN_dt0xRNioR8SugY2hrDk1JA`,
@@ -352,7 +352,7 @@ export const EVENTS = [
       INFO: {
         id: 'public.eng.page.event.listening.4.info',
         defaultMessage: `May 19th (4:00 PM EST)`,
-        description: 'Navigate to the the public engagement page, this will be the public engagement page event listening session 4 date',
+        description: 'Navigate to the public engagement page, this will be the public engagement page event listening session 4 date',
       },
     }),
     REG_LINK: `https://pitc.zoomgov.com/webinar/register/WN_1PR73vLDQpq1zoAWkhKB5g`,

--- a/client/src/data/copy/tsd.tsx
+++ b/client/src/data/copy/tsd.tsx
@@ -6,11 +6,11 @@ export const PAGE_INTRO = defineMessages({
   PAGE_TILE: {
     id: 'technical.support.doc.page.title.text',
     defaultMessage: 'Technical Support Document',
-    description: 'Navigate to the the Technical Support Doc page, this will be the page title text',
+    description: 'Navigate to the Technical Support Doc page, this will be the page title text',
   },
   COMING_SOON: {
     id: 'technical.support.doc.page.coming.soon.text',
     defaultMessage: 'Coming Soon!',
-    description: 'Navigate to the the Technical Support Doc page, this will be the page coming soon text',
+    description: 'Navigate to the Technical Support Doc page, this will be the page coming soon text',
   },
 });

--- a/client/src/intl/en.json
+++ b/client/src/intl/en.json
@@ -132,7 +132,7 @@
     "description": "Navigate to the about page. This is third Footer column header"
   },
   "common.pages.footer.eng.cal.text": {
-    "defaultMessage": "Engagement calender",
+    "defaultMessage": "Engagement calendar",
     "description": "Navigate to the about page. This is Footer eng.cal.gov link text"
   },
   "common.pages.footer.findcontact": {
@@ -176,7 +176,7 @@
     "description": "Navigate to the about page. This is Footer rfi link"
   },
   "common.pages.footer.rfi.text": {
-    "defaultMessage": "Request for Infomation",
+    "defaultMessage": "Request for Information",
     "description": "Navigate to the about page. This is Footer rfi link text"
   },
   "common.pages.footer.whitehouse.link": {
@@ -289,7 +289,7 @@
   },
   "downloads.page.description1.text": {
     "defaultMessage": "The dataset used in the tool, along with a data dictionary and information about how to use the list of communities (.pdf) are available in the following file formats:",
-    "description": "Navigate to the the Downloads page, this will be the page description1 text"
+    "description": "Navigate to the Downloads page, this will be the page description1 text"
   },
   "downloads.page.excel.link": {
     "defaultMessage": "<link1>Excel file</link1> (.xlxs {excelFileSize} unzipped)",
@@ -297,11 +297,11 @@
   },
   "downloads.page.heading1.text": {
     "defaultMessage": "Downloads",
-    "description": "Navigate to the the Downloads page, this will be the page heading1 text"
+    "description": "Navigate to the Downloads page, this will be the page heading1 text"
   },
   "downloads.page.heading2.text": {
     "defaultMessage": "File formats",
-    "description": "Navigate to the the Downloads page, this will be the page heading2 text"
+    "description": "Navigate to the Downloads page, this will be the page heading2 text"
   },
   "downloads.page.shape.link": {
     "defaultMessage": "<link1>Shapefiles </link1> (Codebook included with geojson {shapeFileSize} unzipped)",
@@ -309,10 +309,10 @@
   },
   "downloads.page.title.text": {
     "defaultMessage": "Downloads",
-    "description": "Navigate to the the Downloads page, this will be the page title text"
+    "description": "Navigate to the Downloads page, this will be the page title text"
   },
   "explore.map.page.description.text": {
-    "defaultMessage": "Use the map to see communities that are identified as disadvantaged. The map uses publicly-available, nationally-consistent datasets. Learn more about the methodology and datasets that were used to identify disavantaged communities in the current version of the map on the <link1>Methodology & data</link1> page.",
+    "defaultMessage": "Use the map to see communities that are identified as disadvantaged. The map uses publicly-available, nationally-consistent datasets. Learn more about the methodology and datasets that were used to identify disadvantaged communities in the current version of the map on the <link1>Methodology & data</link1> page.",
     "description": "On the explore the map page, the description of the page"
   },
   "explore.map.page.heading.text": {
@@ -345,11 +345,11 @@
   },
   "explore.map.page.map.territoryFocus.american.samoa.long": {
     "defaultMessage": "American Samoa",
-    "description": "On the explore the map page, on the map, the full name indicating the bounds of American Somoa"
+    "description": "On the explore the map page, on the map, the full name indicating the bounds of American Samoa"
   },
   "explore.map.page.map.territoryFocus.american.samoa.short": {
     "defaultMessage": "AS",
-    "description": "On the explore the map page, on the map, the abbreviated name indicating the bounds of American Somoa"
+    "description": "On the explore the map page, on the map, the abbreviated name indicating the bounds of American Samoa"
   },
   "explore.map.page.map.territoryFocus.commonwealth.nmp.long": {
     "defaultMessage": "Commonwealth of Northern Mariana Islands",
@@ -457,103 +457,103 @@
   },
   "explore.map.page.side.panel.indicator.description.asthma": {
     "defaultMessage": "Weighted percent of people who have been told they have asthma",
-    "description": "Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator desciption of Number of people who have been told they have asthma"
+    "description": "Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator description of Number of people who have been told they have asthma"
   },
   "explore.map.page.side.panel.indicator.description.diabetes": {
     "defaultMessage": "Weighted percent of people ages 18 years and older who have diabetes other than diabetes during pregnancy",
-    "description": "Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator desciption of People ages 18 years and older who have diabetes other than \n      diabetes during pregnancy"
+    "description": "Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator description of People ages 18 years and older who have diabetes other than \n      diabetes during pregnancy"
   },
   "explore.map.page.side.panel.indicator.description.dieselPartMatter": {
     "defaultMessage": "Diesel exhaust in the air",
-    "description": "Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator desciption of Diesel exhaust in the air"
+    "description": "Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator description of Diesel exhaust in the air"
   },
   "explore.map.page.side.panel.indicator.description.energyBurden": {
     "defaultMessage": "Average annual energy costs divided by household income",
-    "description": "Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator desciption of Energy costs divided by household income"
+    "description": "Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator description of Energy costs divided by household income"
   },
   "explore.map.page.side.panel.indicator.description.exp.ag.loss": {
     "defaultMessage": "Economic loss rate to agricultural value resulting from natural hazards each year",
-    "description": "Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator desciption of Economic loss rate to agriculture resulting from naturhazards\n    "
+    "description": "Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator description of Economic loss rate to agriculture resulting from natural hazards\n    "
   },
   "explore.map.page.side.panel.indicator.description.exp.bld.loss": {
     "defaultMessage": "Economic loss rate to agricultural value resulting from natural hazards each year",
-    "description": "Navigate to the explore the map page. When the map is in view, click on the map. The side \n    panel will show an indicator desciption of Economic loss rate to buildings resulting from natural hazards"
+    "description": "Navigate to the explore the map page. When the map is in view, click on the map. The side \n    panel will show an indicator description of Economic loss rate to buildings resulting from natural hazards"
   },
   "explore.map.page.side.panel.indicator.description.exp.pop.loss": {
     "defaultMessage": "Rate of fatalities and injuries resulting from natural hazards each year",
-    "description": "Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator desciption of Economic loss rate to the population in fatalities and \n      injuries resulting from natural hazards"
+    "description": "Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator description of Economic loss rate to the population in fatalities and \n      injuries resulting from natural hazards"
   },
   "explore.map.page.side.panel.indicator.description.heartDisease": {
     "defaultMessage": "People ages 18 years and older who have been told they have heart disease",
-    "description": "Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator desciption of Weighted percent of people ages 18 years and older who have \n    been told they have heart disease"
+    "description": "Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator description of Weighted percent of people ages 18 years and older who have \n    been told they have heart disease"
   },
   "explore.map.page.side.panel.indicator.description.high.ed": {
     "defaultMessage": "Percent of the census tract's population 15 or older not enrolled in college, university, or graduate school",
-    "description": "Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator desciption of Percent of the census tract's population 15 or older not \n      enrolled in college, university, or graduate school"
+    "description": "Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator description of Percent of the census tract's population 15 or older not \n      enrolled in college, university, or graduate school"
   },
   "explore.map.page.side.panel.indicator.description.high.school": {
     "defaultMessage": "Percent of people ages 25 years or older whose education level is less than a high school diploma",
-    "description": "Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator desciption of Percent of people ages 25 years or older whose education level \n      is less than a high school diploma"
+    "description": "Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator description of Percent of people ages 25 years or older whose education level \n      is less than a high school diploma"
   },
   "explore.map.page.side.panel.indicator.description.houseBurden": {
     "defaultMessage": "Low income households spending more than 30% of income on housing",
-    "description": "Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator desciption of Low income households spending more than 30% of income housing\n    "
+    "description": "Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator description of Low income households spending more than 30% of income housing\n    "
   },
   "explore.map.page.side.panel.indicator.description.leadPaint": {
     "defaultMessage": "Percentile of number of homes built before 1960 that are not among the most expensive",
-    "description": "Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator desciption of Pre-1960 housing"
+    "description": "Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator description of Pre-1960 housing"
   },
   "explore.map.page.side.panel.indicator.description.lifeExpect": {
     "defaultMessage": "Average number of years a person can expect to live",
-    "description": "Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator desciption of Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator desciption of Average number of years of life a person can expect to live"
+    "description": "Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator description of Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator description of Average number of years of life a person can expect to live"
   },
   "explore.map.page.side.panel.indicator.description.ling.iso": {
     "defaultMessage": "Percent of households where no one over the age 14 speaks English well",
-    "description": "Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator desciption of Households in which no one age 14 and over speaks English only or also speaks a language other than English"
+    "description": "Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator description of Households in which no one age 14 and over speaks English only or also speaks a language other than English"
   },
   "explore.map.page.side.panel.indicator.description.low.income": {
     "defaultMessage": "Household income is less than or equal to twice the federal poverty level",
-    "description": "Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator desciption of Household income is less than or equal to twice the federal poverty level"
+    "description": "Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator description of Household income is less than or equal to twice the federal poverty level"
   },
   "explore.map.page.side.panel.indicator.description.low.med.income": {
     "defaultMessage": "Median income calculated as a percent of the area’s median income",
-    "description": "Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator desciption of Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator desciption of Median income calculated as a percent of the area’s median income"
+    "description": "Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator description of Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator description of Median income calculated as a percent of the area’s median income"
   },
   "explore.map.page.side.panel.indicator.description.med.home.val": {
     "defaultMessage": "Median home value in area",
-    "description": "Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator desciption of Meidan home value in area"
+    "description": "Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator description of Median home value in area"
   },
   "explore.map.page.side.panel.indicator.description.pm25": {
     "defaultMessage": "Fine inhalable particles, 2.5 micrometers or smaller",
-    "description": "Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator desciption of Fine inhalable particles, 2.5 micrometers and smaller"
+    "description": "Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator description of Fine inhalable particles, 2.5 micrometers and smaller"
   },
   "explore.map.page.side.panel.indicator.description.poverty": {
     "defaultMessage": "Percent of a census tract's population in households where the household income is at or below 100% of the Federal poverty level",
-    "description": "Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator desciption of Percent of individuals in households where the household income is at or below 100% of the federal poverty level"
+    "description": "Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator description of Percent of individuals in households where the household income is at or below 100% of the federal poverty level"
   },
   "explore.map.page.side.panel.indicator.description.prox.haz": {
     "defaultMessage": "Count of hazardous waste facilities within 5 kilometers",
-    "description": "Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator desciption of Count of hazardous waste facilities within 5 kilometers"
+    "description": "Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator description of Count of hazardous waste facilities within 5 kilometers"
   },
   "explore.map.page.side.panel.indicator.description.prox.npl": {
     "defaultMessage": "Proposed or listed NPL (Superfund) sites within 5 kilometers",
-    "description": "Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator desciption of Proposed or listed NPL (Superfund) sites within 5 kilometers"
+    "description": "Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator description of Proposed or listed NPL (Superfund) sites within 5 kilometers"
   },
   "explore.map.page.side.panel.indicator.description.prox.rmp": {
     "defaultMessage": "RMP facilities within 5 kilometers",
-    "description": "Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator desciption of Risk Management Plan facilities within 5 kilometers"
+    "description": "Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator description of Risk Management Plan facilities within 5 kilometers"
   },
   "explore.map.page.side.panel.indicator.description.trafficVolume": {
     "defaultMessage": "Count of vehicles at major roads within 500 meters",
-    "description": "Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator desciption of Count of vehicles at major roads within 500 meters"
+    "description": "Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator description of Count of vehicles at major roads within 500 meters"
   },
   "explore.map.page.side.panel.indicator.description.unemploy": {
     "defaultMessage": "Number of unemployed people as a percentage of the labor force",
-    "description": "Navigate to the explore the map page. When the map is in view, click on the map. The side \n    panel will show an indicator desciption of Number of unemployed people as a percentage of the labor force"
+    "description": "Navigate to the explore the map page. When the map is in view, click on the map. The side \n    panel will show an indicator description of Number of unemployed people as a percentage of the labor force"
   },
   "explore.map.page.side.panel.indicator.description.wasteWater": {
     "defaultMessage": "Toxic concentrations at stream segments within 500 meters",
-    "description": "Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator desciption of Toxic concentrations at stream segments within 500 meters"
+    "description": "Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show an indicator description of Toxic concentrations at stream segments within 500 meters"
   },
   "explore.map.page.side.panel.indicator.diabetes": {
     "defaultMessage": "Diabetes",
@@ -712,7 +712,7 @@
     "description": "Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show Wastewater discharge"
   },
   "explore.map.page.side.panel.info.alt.text.icon1": {
-    "defaultMessage": "An icon that has depicts pieces of a block selected mimicing the census block census tracts",
+    "defaultMessage": "An icon that has depicts pieces of a block selected mimicking the census block census tracts",
     "description": "Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show Things to know, this is the first icon in this side panel"
   },
   "explore.map.page.side.panel.info.alt.text.icon2": {
@@ -749,7 +749,7 @@
   },
   "explore.map.page.side.panel.info.para5": {
     "defaultMessage": "Thresholds for each category determine if a tract should be identified as disadvantaged because it has exceeded a certain value for the relevant indicators.",
-    "description": "Navigate to the explore the map page. When the map is in view, click on the map. The side panelwill show Things to know, this is the fifth paragraph of this side pane"
+    "description": "Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show Things to know, this is the fifth paragraph of this side pane"
   },
   "explore.map.page.side.panel.info.title": {
     "defaultMessage": "Things to know",
@@ -840,12 +840,12 @@
     "description": "Navigate to the explore the map page. Under the map, you will see tribal nations intro text"
   },
   "explore.map.page.under.map.note.on.tribal.nations.para.1": {
-    "defaultMessage": "The map covers all U.S. census tracts, including those located within Tribal Nations, to the extent that data is available (see our <link1>Methodology & data</link1> page for more information). CEQ is engaging in consultation and coordination with Tribal Nations on the beta version of the map to provide Tribal Nations with meaningful opportunities for input, consistent with CEQ’s <link2> Action Plan for Consultation and Coordination with Tribal Nations</link2>, <link3>President Biden’s Memorandum on Tribal Consultation and Strengthening Nation-to-Nation Consultation</link3>, and Executive Order 13175 on <link4>Consulation and Coordination With Indian Tribal Governments</link4>.",
+    "defaultMessage": "The map covers all U.S. census tracts, including those located within Tribal Nations, to the extent that data is available (see our <link1>Methodology & data</link1> page for more information). CEQ is engaging in consultation and coordination with Tribal Nations on the beta version of the map to provide Tribal Nations with meaningful opportunities for input, consistent with CEQ’s <link2> Action Plan for Consultation and Coordination with Tribal Nations</link2>, <link3>President Biden’s Memorandum on Tribal Consultation and Strengthening Nation-to-Nation Consultation</link3>, and Executive Order 13175 on <link4>Consultation and Coordination With Indian Tribal Governments</link4>.",
     "description": "Navigate to the explore the map page. Under the map, you will see tribal nations paragraph 1"
   },
   "explore.tool.page.side.panel.indicator.percentile.value.ordinal.suffix": {
     "defaultMessage": "{indicatorValue, selectordinal, one {#st} two {#nd} =3 {#rd} other {#th} }",
-    "description": "Navigate to the explore the tool page. Click on the map. The side panel will show categories. Open a category. This will define the indicator value's oridinal suffix. For example the st in 91st, the rd in 23rd, and the th in 26th, etc."
+    "description": "Navigate to the explore the tool page. Click on the map. The side panel will show categories. Open a category. This will define the indicator value's ordinal suffix. For example the st in 91st, the rd in 23rd, and the th in 26th, etc."
   },
   "explore.tool.page.side.panel.indicator.title.clean.water": {
     "defaultMessage": "Clean water and wastewater infrastructure",
@@ -853,15 +853,15 @@
   },
   "fab.survey.text": {
     "defaultMessage": "Help improve the site & data",
-    "description": "Navigate to the the public engagement page, this will be the text for floating action button"
+    "description": "Navigate to the public engagement page, this will be the text for floating action button"
   },
   "faqs.page.coming.soon.text": {
     "defaultMessage": "Coming Soon!",
-    "description": "Navigate to the the FAQs page, this will be the page coming soon text"
+    "description": "Navigate to the FAQs page, this will be the page coming soon text"
   },
   "faqs.page.title.text": {
     "defaultMessage": "Frequently asked questions",
-    "description": "Navigate to the the FAQs page, this will be the page title text"
+    "description": "Navigate to the FAQs page, this will be the page title text"
   },
   "indicator.categories.afford.house.title": {
     "defaultMessage": "Affordable and sustainable housing",
@@ -1077,15 +1077,15 @@
   },
   "methodology.page.dataset.card.availableFor.AS_NMI": {
     "defaultMessage": "American Samoa and the Northern Mariana Islands",
-    "description": "Methodoloy page dataset card available for American Samoa and Northern Mariana Islands type"
+    "description": "Methodology page dataset card available for American Samoa and Northern Mariana Islands type"
   },
   "methodology.page.dataset.card.availableFor.US_DC": {
     "defaultMessage": "All U.S. states and the District of Columbia",
-    "description": "Methodoloy page dataset card available for US and DC type"
+    "description": "Methodology page dataset card available for US and DC type"
   },
   "methodology.page.dataset.card.availableFor.US_DC_PR": {
     "defaultMessage": "All U.S. states, the District of Columbia, and Puerto Rico",
-    "description": "Methodoloy page dataset card available for US, DC and Puerto Rico type"
+    "description": "Methodology page dataset card available for US, DC and Puerto Rico type"
   },
   "methodology.page.dataset.indicator.asthma.title.text": {
     "defaultMessage": "Asthma",
@@ -1224,7 +1224,7 @@
     "description": "Navigate to the Methodology page. This is the description of the dataset section"
   },
   "methodology.page.datasets.all.except.workforce.used.in.text": {
-    "defaultMessage": "All categories except for the training and workforce development catetory",
+    "defaultMessage": "All categories except for the training and workforce development category",
     "description": "Navigate to the methodology page. Navigate to the dataset section. This is the portion of the dataset card Used In text for all methodologies except the workforce development"
   },
   "methodology.page.datasets.all.used.in.text": {
@@ -1389,75 +1389,75 @@
   },
   "public.eng.page.button.img.alt.tag": {
     "defaultMessage": "an icon that represents a calendar",
-    "description": "Navigate to the the public engagement page, this will be the public engagement button icon alt tag text"
+    "description": "Navigate to the public engagement page, this will be the public engagement button icon alt tag text"
   },
   "public.eng.page.button.label": {
     "defaultMessage": "Public engagement",
-    "description": "Navigate to the the public engagement page, this will be the public engagement button label"
+    "description": "Navigate to the public engagement page, this will be the public engagement button label"
   },
   "public.eng.page.description1.text": {
     "defaultMessage": "CEQ is hosting engagement opportunities to connect with the public about the current version of the tool. These sessions are an opportunity to obtain training on the tool or to provide feedback on the beta version of the tool. CEQ hopes that members of the public will join these engagements to learn about the tool, have their questions answered, and share feedback.",
-    "description": "Navigate to the the public engagement page, this will be the publiceng page description 1 text"
+    "description": "Navigate to the public engagement page, this will be the publiceng page description 1 text"
   },
   "public.eng.page.description2.text": {
     "defaultMessage": "Pre-registration is required to participate and speak at the sessions.",
-    "description": "Navigate to the the public engagement page, this will be the publiceng page description 2 text"
+    "description": "Navigate to the public engagement page, this will be the publiceng page description 2 text"
   },
   "public.eng.page.description3.text": {
     "defaultMessage": "As they become available, additional public trainings and engagement opportunities on the Climate and Economic Justice Screening Tool will also be posted on this page.",
-    "description": "Navigate to the the public engagement page, this will be the publiceng page description 3 text"
+    "description": "Navigate to the public engagement page, this will be the publiceng page description 3 text"
   },
   "public.eng.page.event.info.label": {
     "defaultMessage": "Event info",
-    "description": "Navigate to the the public engagement page, this will be the public engagement page event info label"
+    "description": "Navigate to the public engagement page, this will be the public engagement page event info label"
   },
   "public.eng.page.event.listening.1.info": {
     "defaultMessage": "March 22nd (4:00 - 5:00 PM EST)",
-    "description": "Navigate to the the public engagement page, this will be the public engagement page event listening session 1 date"
+    "description": "Navigate to the public engagement page, this will be the public engagement page event listening session 1 date"
   },
   "public.eng.page.event.listening.2.info": {
     "defaultMessage": "April 15th (4:00 - 5:00 PM EST)",
-    "description": "Navigate to the the public engagement page, this will be the public engagement page event listening session 2 date"
+    "description": "Navigate to the public engagement page, this will be the public engagement page event listening session 2 date"
   },
   "public.eng.page.event.listening.3.info": {
     "defaultMessage": "May 10th (4:00 PM EST)",
-    "description": "Navigate to the the public engagement page, this will be the public engagement page event listening session 3 date"
+    "description": "Navigate to the public engagement page, this will be the public engagement page event listening session 3 date"
   },
   "public.eng.page.event.listening.4.info": {
     "defaultMessage": "May 19th (4:00 PM EST)",
-    "description": "Navigate to the the public engagement page, this will be the public engagement page event listening session 4 date"
+    "description": "Navigate to the public engagement page, this will be the public engagement page event listening session 4 date"
   },
   "public.eng.page.event.listening.sess.description": {
     "defaultMessage": "CEQ is hosting public listening sessions to seek input and feedback on the beta version of the tool, including on the datasets it includes and the methodology it uses. This feedback is critical to the development and enhancement of the tool. This feedback will help CEQ update and refine the tool to ensure that it reflects the environmental, climate and other challenges that communities are experiencing.",
-    "description": "Navigate to the the public engagement page, this will be the public engagement page event listening session description"
+    "description": "Navigate to the public engagement page, this will be the public engagement page event listening session description"
   },
   "public.eng.page.event.listening.sess.name": {
     "defaultMessage": "listening session",
-    "description": "Navigate to the the public engagement page, this will be the public engagement page event listening session name"
+    "description": "Navigate to the public engagement page, this will be the public engagement page event listening session name"
   },
   "public.eng.page.event.reglink.label": {
     "defaultMessage": "Registration link",
-    "description": "Navigate to the the public engagement page, this will be the public engagment page event registration link label"
+    "description": "Navigate to the public engagement page, this will be the public engagement page event registration link label"
   },
   "public.eng.page.event.training.1.info": {
     "defaultMessage": "March 9th (4:00 - 5:00 PM EST)",
-    "description": "Navigate to the the public engagement page, this will be the public engagement page event training session 1 date"
+    "description": "Navigate to the public engagement page, this will be the public engagement page event training session 1 date"
   },
   "public.eng.page.event.training.2.info": {
     "defaultMessage": "March 10th (4:00 - 5:00 PM EST)",
-    "description": "Navigate to the the public engagement page, this will be the public engagement page event training session 2 date"
+    "description": "Navigate to the public engagement page, this will be the public engagement page event training session 2 date"
   },
   "public.eng.page.event.training.3.info": {
     "defaultMessage": "March 16th (4:00 - 5:00 PM EST)",
-    "description": "Navigate to the the public engagement page, this will be the public engagement page event training session 3 date"
+    "description": "Navigate to the public engagement page, this will be the public engagement page event training session 3 date"
   },
   "public.eng.page.event.training.description": {
     "defaultMessage": "The White House Council on Environmental Quality (CEQ), in partnership with the U.S. Digital Service, is hosting a series of 'Training Webinars' for users of the Climate and Economic Justice Screening Tool. These webinars are an opportunity for members of the public to learn how to use the current version of the tool. The presenters at these webinars will be available to provide technical support and address issues related to accessing and using the tool.",
-    "description": "Navigate to the the public engagement page, this will be the public engagement page event training session description"
+    "description": "Navigate to the public engagement page, this will be the public engagement page event training session description"
   },
   "public.eng.page.event.training.sess.name": {
     "defaultMessage": "training session",
-    "description": "Navigate to the the public engagement page, this will be the public engagement page event training session name"
+    "description": "Navigate to the public engagement page, this will be the public engagement page event training session name"
   },
   "public.eng.page.event.whejac.meeting.day.1.description": {
     "defaultMessage": "The White House Environmental Justice Advisory Council is also soliciting feedback on the beta version of the Climate and Economic Justice Screening Tool at its public meeting. The link above has additional details.",
@@ -1477,43 +1477,43 @@
   },
   "public.eng.page.heading1.text": {
     "defaultMessage": "Public engagement opportunities",
-    "description": "Navigate to the the public engagement page, this will be the publiceng page header text"
+    "description": "Navigate to the public engagement page, this will be the publiceng page header text"
   },
   "public.eng.page.sub.header2.text": {
     "defaultMessage": "Find an event",
-    "description": "Navigate to the the public engagement page, this will be the publiceng page sub header text"
+    "description": "Navigate to the public engagement page, this will be the publiceng page sub header text"
   },
   "public.eng.page.tag.label": {
     "defaultMessage": "UPDATED",
-    "description": "Navigate to the the public engagement page, this will be the public engagement tag label"
+    "description": "Navigate to the public engagement page, this will be the public engagement tag label"
   },
   "public.eng.page.title.text": {
     "defaultMessage": "Public engagement opportunities",
-    "description": "Navigate to the the public engagement page, this will be the publiceng page title text"
+    "description": "Navigate to the public engagement page, this will be the publiceng page title text"
   },
   "public.eng.page.video.box.body.text": {
     "defaultMessage": "Watch a recorded version of the CEJST training on YouTube.",
-    "description": "Navigate to the the public engagement page, there will be box that allows users to watch previously recorded videos. This is that box body text."
+    "description": "Navigate to the public engagement page, there will be box that allows users to watch previously recorded videos. This is that box body text."
   },
   "public.eng.page.video.box.button.img.alt.text1": {
     "defaultMessage": "the icon to show that this button will open in a new tab",
-    "description": "Navigate to the the public engagement page, there will be box that allows users to watch previously recorded videos. This is alt tag of the image in the button."
+    "description": "Navigate to the public engagement page, there will be box that allows users to watch previously recorded videos. This is alt tag of the image in the button."
   },
   "public.eng.page.video.box.button.img.alt.text2": {
     "defaultMessage": "the icon to show that this button will download the file",
-    "description": "Navigate to the the public engagement page, there will be box that allows users to watch previously recorded videos. This is alt tag of the image in the 2nd button."
+    "description": "Navigate to the public engagement page, there will be box that allows users to watch previously recorded videos. This is alt tag of the image in the 2nd button."
   },
   "public.eng.page.video.box.button1.text": {
     "defaultMessage": "Watch on YouTube",
-    "description": "Navigate to the the public engagement page, there will be box that allows users to watch previously recorded videos. This is that box button text."
+    "description": "Navigate to the public engagement page, there will be box that allows users to watch previously recorded videos. This is that box button text."
   },
   "public.eng.page.video.box.button2.text": {
     "defaultMessage": "Download slide deck",
-    "description": "Navigate to the the public engagement page, there will be box that allows users to watch previously recorded videos. This is the button text for the second button."
+    "description": "Navigate to the public engagement page, there will be box that allows users to watch previously recorded videos. This is the button text for the second button."
   },
   "public.eng.page.video.box.title.text": {
     "defaultMessage": "Can't make an upcoming session?",
-    "description": "Navigate to the the public engagement page, there will be box that allows users to watch previously recorded videos. This is that box title text."
+    "description": "Navigate to the public engagement page, there will be box that allows users to watch previously recorded videos. This is that box title text."
   },
   "public.eng.page.whejac.meeting.day.1.info": {
     "defaultMessage": "March 30th (3:00 - 7:00 PM EST)",
@@ -1525,10 +1525,10 @@
   },
   "technical.support.doc.page.coming.soon.text": {
     "defaultMessage": "Coming Soon!",
-    "description": "Navigate to the the Technical Support Doc page, this will be the page coming soon text"
+    "description": "Navigate to the Technical Support Doc page, this will be the page coming soon text"
   },
   "technical.support.doc.page.title.text": {
     "defaultMessage": "Technical Support Document",
-    "description": "Navigate to the the Technical Support Doc page, this will be the page title text"
+    "description": "Navigate to the Technical Support Doc page, this will be the page title text"
   }
 }

--- a/client/src/intl/es_5.4.22-translated-final.json
+++ b/client/src/intl/es_5.4.22-translated-final.json
@@ -1289,7 +1289,7 @@
   },
   "methodology.page.indicator.categories.clean.water.methodology": {
     "defaultMessage": "Categoría de infraestructura crítica para agua no contaminada y residuos",
-    "description": "Navigate to the methodology page. Navigate to the dataset section. This is the portion of the dataset card that populates the Used in section for the Critical clean water and wasterwater infrastructure methodology"
+    "description": "Navigate to the methodology page. Navigate to the dataset section. This is the portion of the dataset card that populates the Used in section for the Critical clean water and wastewater infrastructure methodology"
   },
   "methodology.page.indicator.categories.climate.change.if": {
     "defaultMessage": "<boldtag>SI</boldtag> está en el percentil de 90 o por encima de este para la <link1>tasa prevista de pérdida agrícola</link1> O la <link2>tasa prevista de pérdida de edificios</link2> O la <link3>tasa prevista de pérdida de población</link3>",

--- a/client/src/pages/tests/__snapshots__/about.test.tsx.snap
+++ b/client/src/pages/tests/__snapshots__/about.test.tsx.snap
@@ -941,7 +941,7 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                     class="footer-link-first-child"
                     href="/en/public-engagement"
                   >
-                    Engagement calender
+                    Engagement calendar
                   </a>
                 </li>
                 <li
@@ -949,12 +949,12 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                 >
                   <a
                     class="usa-link usa-link--external"
-                    data-cy="request-for-infomation"
+                    data-cy="request-for-information"
                     href="https://www.federalregister.gov/d/2022-03920"
                     rel="noreferrer"
                     target="_blank"
                   >
-                    Request for Infomation
+                    Request for Information
                   </a>
                 </li>
                 <li

--- a/client/src/pages/tests/__snapshots__/contact.test.tsx.snap
+++ b/client/src/pages/tests/__snapshots__/contact.test.tsx.snap
@@ -611,7 +611,7 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                     class="footer-link-first-child"
                     href="/en/public-engagement"
                   >
-                    Engagement calender
+                    Engagement calendar
                   </a>
                 </li>
                 <li
@@ -619,12 +619,12 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                 >
                   <a
                     class="usa-link usa-link--external"
-                    data-cy="request-for-infomation"
+                    data-cy="request-for-information"
                     href="https://www.federalregister.gov/d/2022-03920"
                     rel="noreferrer"
                     target="_blank"
                   >
-                    Request for Infomation
+                    Request for Information
                   </a>
                 </li>
                 <li

--- a/client/src/pages/tests/__snapshots__/downloads.test.tsx.snap
+++ b/client/src/pages/tests/__snapshots__/downloads.test.tsx.snap
@@ -511,7 +511,7 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                     class="footer-link-first-child"
                     href="/en/public-engagement"
                   >
-                    Engagement calender
+                    Engagement calendar
                   </a>
                 </li>
                 <li
@@ -519,12 +519,12 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                 >
                   <a
                     class="usa-link usa-link--external"
-                    data-cy="request-for-infomation"
+                    data-cy="request-for-information"
                     href="https://www.federalregister.gov/d/2022-03920"
                     rel="noreferrer"
                     target="_blank"
                   >
-                    Request for Infomation
+                    Request for Information
                   </a>
                 </li>
                 <li

--- a/client/src/pages/tests/__snapshots__/freqAskedQuestions.test.tsx.snap
+++ b/client/src/pages/tests/__snapshots__/freqAskedQuestions.test.tsx.snap
@@ -473,7 +473,7 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                     class="footer-link-first-child"
                     href="/en/public-engagement"
                   >
-                    Engagement calender
+                    Engagement calendar
                   </a>
                 </li>
                 <li
@@ -481,12 +481,12 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                 >
                   <a
                     class="usa-link usa-link--external"
-                    data-cy="request-for-infomation"
+                    data-cy="request-for-information"
                     href="https://www.federalregister.gov/d/2022-03920"
                     rel="noreferrer"
                     target="_blank"
                   >
-                    Request for Infomation
+                    Request for Information
                   </a>
                 </li>
                 <li

--- a/client/src/pages/tests/__snapshots__/methodology.test.tsx.snap
+++ b/client/src/pages/tests/__snapshots__/methodology.test.tsx.snap
@@ -1174,7 +1174,7 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                     <span>
                       Used in: 
                     </span>
-                    All categories except for the training and workforce development catetory
+                    All categories except for the training and workforce development category
                   </li>
                   <li>
                     <span>
@@ -2573,7 +2573,7 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                     class="footer-link-first-child"
                     href="/en/public-engagement"
                   >
-                    Engagement calender
+                    Engagement calendar
                   </a>
                 </li>
                 <li
@@ -2581,12 +2581,12 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                 >
                   <a
                     class="usa-link usa-link--external"
-                    data-cy="request-for-infomation"
+                    data-cy="request-for-information"
                     href="https://www.federalregister.gov/d/2022-03920"
                     rel="noreferrer"
                     target="_blank"
                   >
-                    Request for Infomation
+                    Request for Information
                   </a>
                 </li>
                 <li

--- a/client/src/pages/tests/__snapshots__/publicEng.test.tsx.snap
+++ b/client/src/pages/tests/__snapshots__/publicEng.test.tsx.snap
@@ -1078,7 +1078,7 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                     class="footer-link-first-child"
                     href="/en/public-engagement"
                   >
-                    Engagement calender
+                    Engagement calendar
                   </a>
                 </li>
                 <li
@@ -1086,12 +1086,12 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                 >
                   <a
                     class="usa-link usa-link--external"
-                    data-cy="request-for-infomation"
+                    data-cy="request-for-information"
                     href="https://www.federalregister.gov/d/2022-03920"
                     rel="noreferrer"
                     target="_blank"
                   >
-                    Request for Infomation
+                    Request for Information
                   </a>
                 </li>
                 <li

--- a/client/src/pages/tests/__snapshots__/techSupportDoc.test.tsx.snap
+++ b/client/src/pages/tests/__snapshots__/techSupportDoc.test.tsx.snap
@@ -473,7 +473,7 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                     class="footer-link-first-child"
                     href="/en/public-engagement"
                   >
-                    Engagement calender
+                    Engagement calendar
                   </a>
                 </li>
                 <li
@@ -481,12 +481,12 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                 >
                   <a
                     class="usa-link usa-link--external"
-                    data-cy="request-for-infomation"
+                    data-cy="request-for-information"
                     href="https://www.federalregister.gov/d/2022-03920"
                     rel="noreferrer"
                     target="_blank"
                   >
-                    Request for Infomation
+                    Request for Information
                   </a>
                 </li>
                 <li


### PR DESCRIPTION
# Purpose
- closes #1629 

# QA
@katherinedm-usds - thanks for this exhaustive list of changes. It made checking and creating this QA spec very easy (it was just copy paste!) 

## QA links

QA link for changes that are on the site are [here](http://usds-geoplatform-justice40-website.s3-website-us-east-1.amazonaws.com/justice40-tool/1648-f741d3/en/#3/33.47/-97.5).
QA link for changes that are just in the en.json file and not on the site is [here](https://github.com/usds/justice40-tool/blob/06d07da36dd311c2b409d0f7f5b2902b72eb818d/client/src/intl/en.json).

## QA spec

There are typos in the en.json that should be addressed

- [ ] "disavantaged" should be changed to "disadvantaged", this is viewable on the site
`    "defaultMessage": "Use the map to see communities that are identified as disadvantaged. The map uses publicly-available, nationally-consistent datasets. Learn more about the methodology and datasets that were used to identify disavantaged communities in the current version of the tool on the <link1>Methodology & data</link1> page.",`

![image.png](https://images.zenhubusercontent.com/609ab603576fa56647137b9e/48e15a96-d2a8-432f-b862-0a14a05171e3)

- [ ] "calender" should be "calendar" - this is visible on the footer
```
  "common.pages.footer.eng.cal.text": {
    "defaultMessage": "Engagement calender",
```
![image.png](https://images.zenhubusercontent.com/609ab603576fa56647137b9e/e0cd0c66-81e9-451c-9000-a8779160686f)

- [ ] "infomation" should be changed to "information", this is visible on the footer
```
  "common.pages.footer.rfi.text": {
    "defaultMessage": "Request for Infomation",
```

`![image.png](https://images.zenhubusercontent.com/609ab603576fa56647137b9e/de21e537-fe8c-4107-b54f-6f56bb67b58f)`

- [ ] "catetory" should be "category" - this is visible on the site
```
  "methodology.page.datasets.all.except.workforce.used.in.text": {
    "defaultMessage": "All categories except for the training and workforce development catetory",
```
![image.png](https://images.zenhubusercontent.com/609ab603576fa56647137b9e/3636bf23-2489-47c5-8e01-4b6b3b353748)

- [ ] "Consulation" should be replaced with "Consultation", this is visible on the site

`and Executive Order 13175 on <link4>Consulation and Coordination With Indian Tribal Governments</link4>.",`

![image.png](https://images.zenhubusercontent.com/609ab603576fa56647137b9e/d6e4603b-28d5-4bd9-a668-4a1aa313b0e0)

- [ ] "wasterwater" should be replaced with "wastewater", this is viewable on the site but also should be replaced in all places it occurs on the en.json
```
  "indicator.categories.clean.water.title": {
    "defaultMessage": "Critical clean water and wasterwater infrastructure",
    "description": "Navigate to the methodology page. Navigate to the category section. This will set the category title"
  },
```
![image.png](https://images.zenhubusercontent.com/609ab603576fa56647137b9e/b02abf3f-3c3d-4cbe-981a-c17b49755cee)

```
    "description": "Navigate to the methodology page. Navigate to the dataset section. This is the portion of the dataset card that populates the Used in section for the Critical clean water and wasterwater infrastructure methodology"
  },
```


- [ ] "oridnal" should be "ordinal" - this is not visible on the site, but still should be fixed
```
    "description": "Navigate to the explore the tool page. Click on the map. The side panel will show categories. Open a category. This will define the indicator value's oridinal suffix. For example the st in 91st, the rd in 23rd, and the th in 26th, etc."
  },
```

 - [ ] "Somoa" should be "Samoa", this is not visible but should still be fixed  in all places it occurs
```
"defaultMessage": "American Samoa",
    "description": "On the explore the tool page, on the map, the full name indicating the bounds of American Somoa"
  },

```
- [ ] "desciption" should be changed to "description", this comes up many times and though it's not visible on the site, it should be replaced in all cases
```
  "explore.tool.page.side.panel.indicator.description.asthma": {
    "defaultMessage": "Weighted percent of people who have been told they have asthma",
    "description": "Navigate to the explore the tool page. When the map is in view, click on the map. The side panel will show an indicator desciption of Number of people who have been told they have asthma"
  },
```

- [ ] "naturhazards" should be changed to "natural hazards", this is not viewable on the site but should be changed
```
    "description": "Navigate to the explore the tool page. When the map is in view, click on the map. The side panel will show an indicator desciption of Economic loss rate to agriculture resulting from naturhazards\n    "
  },
```

- [ ] "Meidan" should be changed to "Median", it's not visible on the site but should be changed

```
  "description": "Navigate to the explore the tool page. When the map is in view, click on the map. The side panel will show an indicator desciption of Meidan home value in area"
  },
```


- [ ] "mimicing" should be changed to "mimicking", this is not viewable on the site but still should be updated

```
  "explore.tool.page.side.panel.info.alt.text.icon1": {
    "defaultMessage": "An icon that has depicts pieces of a block selected mimicing the census block census tracts",
```


- [ ] "panelwill" should be updated to "panel will", this is not viewable on the site but still should be changed

```
    "description": "Navigate to the explore the tool page. When the map is in view, click on the map. The side panelwill show Things to know, this is the fifth paragraph of this side pane"
  },
```


- [ ] "Methodoloy" should be replaced with "Methodology", this is not viewable on the site but should be replaced in all places it appears
```
    "defaultMessage": "American Samoa and the Northern Mariana Islands",
    "description": "Methodoloy page dataset card available for American Samoa and Northern Mariana Islands type"
  },
```

- [ ] "engagment" should be changed to "engagement", this is not viewable on the site
```
    "description": "Navigate to the the public engagement page, this will be the public engagment page event registration link label"
  },
```

- [ ] any instance of "the the" replace with "the", this is not viewable on the site

```
    "defaultMessage": "Watch a recorded version of the CEJST training on YouTube.",
    "description": "Navigate to the the public engagement page, there will be box that allows users to watch previously recorded videos. This is that box body text."
  },
```