### PR TITLE
Do not drop Guam and USVI from ETL

### DIFF
--- a/data/data-pipeline/data_pipeline/etl/score/constants.py
+++ b/data/data-pipeline/data_pipeline/etl/score/constants.py
@@ -99,6 +99,9 @@ ISLAND_AREAS_EXPLANATION = (
 # Column subsets
 CENSUS_COUNTIES_COLUMNS = ["USPS", "GEOID", "NAME"]
 
+# Drop FIPS codes from map
+DROP_FIPS_CODES = []
+
 # Drop FIPS codes from incrementing
 DROP_FIPS_FROM_NON_WTD_THRESHOLDS = "72"
 

--- a/data/data-pipeline/data_pipeline/etl/score/constants.py
+++ b/data/data-pipeline/data_pipeline/etl/score/constants.py
@@ -99,9 +99,6 @@ ISLAND_AREAS_EXPLANATION = (
 # Column subsets
 CENSUS_COUNTIES_COLUMNS = ["USPS", "GEOID", "NAME"]
 
-# Drop FIPS codes from map
-DROP_FIPS_CODES = ["66", "78"]
-
 # Drop FIPS codes from incrementing
 DROP_FIPS_FROM_NON_WTD_THRESHOLDS = "72"
 

--- a/data/data-pipeline/data_pipeline/etl/score/etl_score_post.py
+++ b/data/data-pipeline/data_pipeline/etl/score/etl_score_post.py
@@ -254,32 +254,6 @@ class PostScoreETL(ExtractTransformLoad):
             tiles_score_column_titles
         ].copy()
 
-        # Currently, we do not want USVI or Guam on the map, so this will drop all
-        # rows with the FIPS codes (first two digits of the census tract)
-        logger.info(
-            f"Dropping specified FIPS codes from tile data: {constants.DROP_FIPS_CODES}"
-        )
-        tracts_to_drop = []
-        for fips_code in constants.DROP_FIPS_CODES:
-            tracts_to_drop += score_tiles[
-                score_tiles[field_names.GEOID_TRACT_FIELD].str.startswith(
-                    fips_code
-                )
-            ][field_names.GEOID_TRACT_FIELD].to_list()
-        score_tiles = score_tiles[
-            ~score_tiles[field_names.GEOID_TRACT_FIELD].isin(tracts_to_drop)
-        ]
-
-        score_tiles[constants.TILES_SCORE_FLOAT_COLUMNS] = score_tiles[
-            constants.TILES_SCORE_FLOAT_COLUMNS
-        ].apply(
-            func=lambda series: floor_series(
-                series=series,
-                number_of_decimals=constants.TILES_ROUND_NUM_DECIMALS,
-            ),
-            axis=0,
-        )
-
         logger.info("Adding fields for island areas and Puerto Rico")
         # The below operation constructs variables for the front end.
         # Since the Island Areas, Puerto Rico, and the nation all have a different


### PR DESCRIPTION
Closes 1662.

This removes code that drops these two territories from the ETL and subsequent score data generation process.

Notably, tests are not currently passing on my machine (and they didn't pass before making the change). I need to figure that out before this can be fully done, assuming that this PR's build will fail when it runs the python tests.