### PR TITLE
Align zoom levels

### DIFF
--- a/client/src/data/constants.tsx
+++ b/client/src/data/constants.tsx
@@ -208,7 +208,7 @@ export const GLOBAL_MIN_ZOOM_LOW = 3;
 export const GLOBAL_MAX_ZOOM_LOW = 7;
 export const GLOBAL_MIN_ZOOM_HIGH = 7;
 export const GLOBAL_MAX_ZOOM_HIGH = 11;
-export const GLOBAL_MIN_ZOOM_FEATURE_BORDER = 8;
+export const GLOBAL_MIN_ZOOM_FEATURE_BORDER = 7;
 export const GLOBAL_MAX_ZOOM_FEATURE_BORDER = 22;
 
 // Opacity


### PR DESCRIPTION
# Purpose
- Align zoom levels between the transition between low to high zoom with the census tract boundary
- closes #1645 

## QA

### QA link [here](http://usds-geoplatform-justice40-website.s3-website-us-east-1.amazonaws.com/justice40-tool/1703-e25d36/en/#3/33.47/-97.5)

QA spec
- [x] when zooming from zoom level 6 to 7 to 8 do the census tract borders show up at the desired time?