### PR TITLE
1831 Follow up

### DIFF
--- a/data/data-pipeline/data_pipeline/etl/score/etl_utils.py
+++ b/data/data-pipeline/data_pipeline/etl/score/etl_utils.py
@@ -364,7 +364,7 @@ def compare_to_list_of_expected_state_fips_codes(
     # If continental US is not expected to be included, remove it from the
     # expected states set.
     if not continental_us_expected:
-        expected_states_set = expected_states_set - set(
+        expected_states_set = expected_states_set.difference(
             TILES_CONTINENTAL_US_FIPS_CODE
         )
 
@@ -374,27 +374,27 @@ def compare_to_list_of_expected_state_fips_codes(
     # do not use this argument -- instead, use `additional_fips_codes_not_expected`
     # for the 1 state you expected to be missing.
     if not alaska_and_hawaii_expected:
-        expected_states_set = expected_states_set - set(
+        expected_states_set = expected_states_set.difference(
             TILES_ALASKA_AND_HAWAII_FIPS_CODE
         )
 
     # If Puerto Rico is not expected to be included, remove it from the expected
     # states set.
     if not puerto_rico_expected:
-        expected_states_set = expected_states_set - set(
+        expected_states_set = expected_states_set.difference(
             TILES_PUERTO_RICO_FIPS_CODE
         )
 
     # If island areas are not expected to be included, remove them from the expected
     # states set.
     if not island_areas_expected:
-        expected_states_set = expected_states_set - set(
+        expected_states_set = expected_states_set.difference(
             TILES_ISLAND_AREA_FIPS_CODES
         )
 
     # If additional FIPS codes are not expected to be included, remove them from the
     # expected states set.
-    expected_states_set = expected_states_set - set(
+    expected_states_set = expected_states_set.difference(
         additional_fips_codes_not_expected
     )
 

--- a/data/data-pipeline/data_pipeline/etl/sources/nlcd_nature_deprived/etl.py
+++ b/data/data-pipeline/data_pipeline/etl/sources/nlcd_nature_deprived/etl.py
@@ -22,9 +22,6 @@ class NatureDeprivedETL(ExtractTransformLoad):
     PUERTO_RICO_EXPECTED_IN_DATA = False
     ALASKA_AND_HAWAII_EXPECTED_IN_DATA = False
 
-    # Alaska and Hawaii are missing
-    EXPECTED_MISSING_STATES = ["02", "15"]
-
     # Output score variables (values set on datasets.yml) for linting purposes
     ELIGIBLE_FOR_NATURE_DEPRIVED_FIELD_NAME: str
     TRACT_PERCENT_IMPERVIOUS_FIELD_NAME: str


### PR DESCRIPTION
It looks like I forgot to commit and push these changes that I made while wrapping up 1831. Pushing them now.

This code causes no functional change to the code. It does two things: 

1. Uses `difference` instead of `-` to improve code style for working with sets. 
2. Removes the line `EXPECTED_MISSING_STATES = ["02", "15"]`, which is now redundant because of the line I added (in a previous pull request) of `ALASKA_AND_HAWAII_EXPECTED_IN_DATA = False`. 