### PR TITLE
Remove markdown link from markdown checker

### DIFF
--- a/data/data-pipeline/data_pipeline/etl/sources/michigan_ejscreen/README.md
+++ b/data/data-pipeline/data_pipeline/etl/sources/michigan_ejscreen/README.md
@@ -1,7 +1,8 @@
 # Michigan EJSCREEN
 
+<!-- markdown-link-check-disable -->
 The Michigan EJSCREEN description and publication can be found [here](https://deepblue.lib.umich.edu/bitstream/handle/2027.42/149105/AssessingtheStateofEnvironmentalJusticeinMichigan_344.pdf).
-
+<!-- markdown-link-check-enable-->
 
 #### Some notes about the input source data column fields:
 


### PR DESCRIPTION
This broken markdown link is causing the FE release branch to fail. Hoping to get this merged into main so that the FE release branch doesn't have to build the BE for each FE fix