### PR TITLE
No issue #: `black` update to remove specific version from pre-commit

### DIFF
--- a/data/data-pipeline/.pre-commit-config.yaml
+++ b/data/data-pipeline/.pre-commit-config.yaml
@@ -35,5 +35,4 @@ repos:
   rev: 22.8.0
   hooks:
     - id: black
-      language_version: python3.9
       args: [--config=./data/data-pipeline/pyproject.toml]


### PR DESCRIPTION
Based on a great comment from @mattbowen-usds on a previous PR that I missed (https://github.com/usds/justice40-tool/pull/1962#discussion_r987226400). 