### PR TITLE
Issue 1992: Do not impute income for null population tracts 

### DIFF
--- a/data/data-pipeline/data_pipeline/etl/sources/census_acs/etl_imputations.py
+++ b/data/data-pipeline/data_pipeline/etl/sources/census_acs/etl_imputations.py
@@ -76,10 +76,10 @@ def _prepare_dataframe_for_imputation(
             # First, check whether any of the columns we want to impute contain null
             # values
             geo_df[imputing_cols].isna().any(axis=1)
-            # Second, ensure population is either null or >= the minimum population
+            # Second, ensure population is not null and >= the minimum population
             & (
-                geo_df[population_field].isnull()
-                | (
+                geo_df[population_field].notnull()
+                & (
                     geo_df[population_field]
                     >= minimum_population_required_for_imputation
                 )


### PR DESCRIPTION
#1992. 

Weirdly, this doesn't seem to have affected any tracts? Because we already has this as a smoketest that was passing: 

```
# Make sure that any tracts with null population have null imputed income
    tracts_with_null_population_df = final_score_df[
        final_score_df[field_names.TOTAL_POP_FIELD].isnull()
    ]
    assert (
        tracts_with_null_population_df[
            field_names.POVERTY_LESS_THAN_200_FPL_IMPUTED_FIELD
        ]
        .isna()
        .all()
    )
```

So maybe the `null` population tracts got cast to `0` population somewhere in the scoring process? 