### PR TITLE
Disable file size limits on tiles

### DIFF
--- a/data/data-pipeline/data_pipeline/tile/generate.py
+++ b/data/data-pipeline/data_pipeline/tile/generate.py
@@ -45,7 +45,6 @@ def generate_tiles(data_path: Path, generate_tribal_layer: bool) -> None:
         cmd += "--no-feature-limit --no-tile-size-limit "
         cmd += f"--output={high_tile_path}/usa_high.mbtiles "
         cmd += str(score_geojson_dir / "usa-high.json")
-        print(cmd)
         call(cmd, shell=True)
 
         # generate high mvts
@@ -55,7 +54,6 @@ def generate_tiles(data_path: Path, generate_tribal_layer: bool) -> None:
         cmd += "--no-feature-limit  --no-tile-size-limit "
         cmd += f"--output-to-directory={high_tile_path} --layer=blocks "
         cmd += str(score_geojson_dir / "usa-high.json")
-        print(cmd)
         call(cmd, shell=True)
 
         # generate low mbtiles file
@@ -64,7 +62,6 @@ def generate_tiles(data_path: Path, generate_tribal_layer: bool) -> None:
         cmd += f"--minimum-zoom={USA_LOW_MIN_ZOOM} --maximum-zoom={USA_LOW_MAX_ZOOM} --layer=blocks "
         cmd += f"--output={low_tile_path}/usa_low.mbtiles "
         cmd += str(score_geojson_dir / "usa-low.json")
-        print(cmd)
         call(cmd, shell=True)
 
         # generate low mvts
@@ -74,7 +71,6 @@ def generate_tiles(data_path: Path, generate_tribal_layer: bool) -> None:
         cmd += "--drop-densest-as-needed "
         cmd += f"--output-to-directory={low_tile_path} --layer=blocks "
         cmd += str(score_geojson_dir / "usa-low.json")
-        print(cmd)
         call(cmd, shell=True)
 
     def _generate_tribal_tiles() -> None:

--- a/data/data-pipeline/data_pipeline/tile/generate.py
+++ b/data/data-pipeline/data_pipeline/tile/generate.py
@@ -42,17 +42,20 @@ def generate_tiles(data_path: Path, generate_tribal_layer: bool) -> None:
         logger.info("Generating USA High mbtiles file")
         cmd = "tippecanoe "
         cmd += f"--minimum-zoom={USA_HIGH_MIN_ZOOM} --maximum-zoom={USA_HIGH_MAX_ZOOM} --layer=blocks "
+        cmd += "--no-feature-limit --no-tile-size-limit "
         cmd += f"--output={high_tile_path}/usa_high.mbtiles "
         cmd += str(score_geojson_dir / "usa-high.json")
+        print(cmd)
         call(cmd, shell=True)
 
         # generate high mvts
         logger.info("Generating USA High mvt folders and files")
         cmd = "tippecanoe "
         cmd += f"--minimum-zoom={USA_HIGH_MIN_ZOOM} --maximum-zoom={USA_HIGH_MAX_ZOOM} --no-tile-compression "
-        cmd += "--drop-densest-as-needed "
+        cmd += "--no-feature-limit  --no-tile-size-limit "
         cmd += f"--output-to-directory={high_tile_path} --layer=blocks "
         cmd += str(score_geojson_dir / "usa-high.json")
+        print(cmd)
         call(cmd, shell=True)
 
         # generate low mbtiles file
@@ -61,6 +64,7 @@ def generate_tiles(data_path: Path, generate_tribal_layer: bool) -> None:
         cmd += f"--minimum-zoom={USA_LOW_MIN_ZOOM} --maximum-zoom={USA_LOW_MAX_ZOOM} --layer=blocks "
         cmd += f"--output={low_tile_path}/usa_low.mbtiles "
         cmd += str(score_geojson_dir / "usa-low.json")
+        print(cmd)
         call(cmd, shell=True)
 
         # generate low mvts
@@ -70,6 +74,7 @@ def generate_tiles(data_path: Path, generate_tribal_layer: bool) -> None:
         cmd += "--drop-densest-as-needed "
         cmd += f"--output-to-directory={low_tile_path} --layer=blocks "
         cmd += str(score_geojson_dir / "usa-low.json")
+        print(cmd)
         call(cmd, shell=True)
 
     def _generate_tribal_tiles() -> None:


### PR DESCRIPTION
After initial analysis, we realized that tracts appear and disappear between zoom levels 5-7 because tippecanoe limits vector tiles to 500kb by default, and we were telling it to drop features to stay under that 500kb. For about 20% of tiles at zoom level 5, we can't stay easily under 500kb. To restore map functionality, we've removed these caps, and follow-on work will reduce the tile sizes as much as practical. 