### PR TITLE
fix: update ua-parser

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -16781,11 +16781,11 @@
       }
     },
     "react-device-detect": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/react-device-detect/-/react-device-detect-1.17.0.tgz",
-      "integrity": "sha512-bBblIStwpHmoS281JFIVqeimcN3LhpoP5YKDWzxQdBIUP8S2xPvHDgizLDhUq2ScguLfVPmwfF5y268EEQR60w==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/react-device-detect/-/react-device-detect-2.2.2.tgz",
+      "integrity": "sha512-zSN1gIAztUekp5qUT/ybHwQ9fmOqVT1psxpSlTn1pe0CO+fnJHKRLOWWac5nKxOxvOpD/w84hk1I+EydrJp7SA==",
       "requires": {
-        "ua-parser-js": "^0.7.24"
+        "ua-parser-js": "^1.0.2"
       }
     },
     "react-dom": {
@@ -20128,9 +20128,9 @@
       "dev": true
     },
     "ua-parser-js": {
-      "version": "0.7.31",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.31.tgz",
-      "integrity": "sha512-qLK/Xe9E2uzmYI3qLeOmI0tEOt+TBBQyUIAh4aAgU05FVYzeZrKUdkAZfBNVGRaHVgV0TDkdEngJSw/SyQchkQ=="
+      "version": "1.0.33",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.33.tgz",
+      "integrity": "sha512-RqshF7TPTE0XLYAqmjlu5cLLuGdKrNu9O1KLA/qp39QtbZwuzwv1dT46DZSopoUMsYgXpB3Cv8a03FI8b74oFQ=="
     },
     "umd": {
       "version": "3.0.3",

--- a/client/package.json
+++ b/client/package.json
@@ -88,7 +88,7 @@
     "maplibre-gl": "^1.14.0",
     "query-string": "^7.1.3",
     "react": "^17.0.2",
-    "react-device-detect": "^1.17.0",
+    "react-device-detect": "^2.2.2",
     "react-dom": "^17.0.2",
     "react-helmet": "^6.1.0",
     "react-intl": "^5.24.7",


### PR DESCRIPTION
This will update a transitive dependency to mitigate a security vulnerability flagged by dependabot.

For those that are able to do a PR review:

This will require a quick test on mobile. Warning: the mobile experience is far from great.  This test is mainly to increase confidence that regressions weren't introduced.

The direct dependency that was updated is used for mobile detection. Which is being used to render the map on mobile and also to handle the case when the open source community member isn't using Mapbox (paid). 

- [ ] Given the staging link, see if the map renders and operates in the same manner as production. 

Regressions would be obvious like
1. map doesn't render
2. map is not clickable

