### PR TITLE
correct ordinal prefix for percentiles ending in 3

### DIFF
--- a/client/src/components/Indicator/Indicator.tsx
+++ b/client/src/components/Indicator/Indicator.tsx
@@ -128,7 +128,7 @@ export const IndicatorValueSubText = ({type, value, isAboveThresh, threshold}:II
  *
  * The i18n variable named i18nOrdinalSuffix, in the IndicatorValue function defines the
  * various prefixes. The Spanish version of the i18n variable works in a similar manner,
- * however has a differnce. The superscripting is different for Spanish.
+ * however has a difference. The superscripting is different for Spanish.
  * In Spanish, the suffix is a ".a" and ".o", where only the "a" and "o" are superscripted.
  * This function handles this case.
  *
@@ -199,7 +199,7 @@ export const IndicatorValue = ({type, displayStat}:IIndicatorValue) => {
         {indicatorValue, selectordinal, 
           one {#st} 
           two {#nd}
-          =3 {#rd} 
+          few {#rd} 
           other {#th}
         }
         `,

--- a/client/src/intl/en.json
+++ b/client/src/intl/en.json
@@ -1124,7 +1124,7 @@
     "description": "Navigate to the explore the map page. When the map is in view, click on the map. The side panel will show Housing cost burden"
   },
   "explore.map.page.side.panel.indicator.percentile.value.ordinal.suffix": {
-    "defaultMessage": "{indicatorValue, selectordinal, one {#st} two {#nd} =3 {#rd} other {#th} }",
+    "defaultMessage": "{indicatorValue, selectordinal, one {#st} two {#nd} few {#rd} other {#th} }",
     "description": "Navigate to the explore the tool page. Click on the map. The side panel will show categories. Open a category. This will define the indicator value's ordinal suffix. For example the st in 91st, the rd in 23rd, and the th in 26th, etc."
   },
   "explore.map.page.side.panel.indicator.pm25": {


### PR DESCRIPTION
- closes #2187
QA:

This tract seems to have a good distribution of percentile values to test the ordinal suffix:

https://screeningtool-staging.geoplatform.gov/2188-2118bd/en/#10.87/35.4313/-91.7441