### PR TITLE
Fix broken EJScreen Link

### DIFF
--- a/client/src/components/DatasetContainer/tests/__snapshots__/datasetContainer.test.tsx.snap
+++ b/client/src/components/DatasetContainer/tests/__snapshots__/datasetContainer.test.tsx.snap
@@ -563,7 +563,7 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                   <a
                     class="usa-link usa-link--external"
                     data-cy=""
-                    href="https://www.epa.gov/ejscreen/technical-documentation-ejscreen"
+                    href="https://www.epa.gov/ejscreen/download-ejscreen-data"
                     rel="noreferrer"
                     target="_blank"
                   >
@@ -1381,7 +1381,7 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                   <a
                     class="usa-link usa-link--external"
                     data-cy=""
-                    href="https://www.epa.gov/ejscreen/technical-documentation-ejscreen"
+                    href="https://www.epa.gov/ejscreen/download-ejscreen-data"
                     rel="noreferrer"
                     target="_blank"
                   >
@@ -1432,7 +1432,7 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                   <a
                     class="usa-link usa-link--external"
                     data-cy=""
-                    href="https://www.epa.gov/ejscreen/technical-documentation-ejscreen"
+                    href="https://www.epa.gov/ejscreen/download-ejscreen-data"
                     rel="noreferrer"
                     target="_blank"
                   >
@@ -1551,7 +1551,7 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                   <a
                     class="usa-link usa-link--external"
                     data-cy=""
-                    href="https://www.epa.gov/ejscreen/technical-documentation-ejscreen"
+                    href="https://www.epa.gov/ejscreen/download-ejscreen-data"
                     rel="noreferrer"
                     target="_blank"
                   >
@@ -1662,7 +1662,7 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                   <a
                     class="usa-link usa-link--external"
                     data-cy=""
-                    href="https://www.epa.gov/ejscreen/technical-documentation-ejscreen"
+                    href="https://www.epa.gov/ejscreen/download-ejscreen-data"
                     rel="noreferrer"
                     target="_blank"
                   >

--- a/client/src/data/copy/methodology.tsx
+++ b/client/src/data/copy/methodology.tsx
@@ -611,7 +611,7 @@ export const SOURCE_LINKS = {
     `}
     description={'Navigate to the Methodology page. This is the source link for EPA OAR'}
     values={{
-      link1: linkFn('https://www.epa.gov/ejscreen/technical-documentation-ejscreen', false, true),
+      link1: linkFn('https://www.epa.gov/ejscreen/download-ejscreen-data', false, true),
       date17: DATE_RANGE.SEVENTEEN,
     }}
   />,
@@ -620,7 +620,7 @@ export const SOURCE_LINKS = {
     defaultMessage={`<link1>National Air Toxics Assessment (NATA)</link1> from {date14} as compiled by EPA's EJScreen`}
     description={'Navigate to the Methodology page. This is the source link for EPA NATA'}
     values={{
-      link1: linkFn('https://www.epa.gov/ejscreen/technical-documentation-ejscreen', false, true),
+      link1: linkFn('https://www.epa.gov/ejscreen/download-ejscreen-data', false, true),
       date14: DATE_RANGE.FOURTEEN,
     }}
   />,
@@ -629,7 +629,7 @@ export const SOURCE_LINKS = {
     defaultMessage={`<link1>Traffic data</link1> from {date17} as compiled by EPA's EJScreen`}
     description={'Navigate to the Methodology page. This is the source link for DOT EPA'}
     values={{
-      link1: linkFn('https://www.epa.gov/ejscreen/technical-documentation-ejscreen', false, true),
+      link1: linkFn('https://www.epa.gov/ejscreen/download-ejscreen-data', false, true),
       date17: DATE_RANGE.SEVENTEEN,
     }}
   />,
@@ -668,7 +668,7 @@ export const SOURCE_LINKS = {
     defaultMessage={`<link1>RMP database</link1> from {date20} as compiled by EPA’s EJScreen`}
     description={'Navigate to the Methodology page. This is the source link for EPA RMP'}
     values={{
-      link1: linkFn('https://www.epa.gov/ejscreen/technical-documentation-ejscreen', false, true),
+      link1: linkFn('https://www.epa.gov/ejscreen/download-ejscreen-data', false, true),
       date20: DATE_RANGE.TWENTY,
     }}
   />,
@@ -677,7 +677,7 @@ export const SOURCE_LINKS = {
     defaultMessage={`<link1>Risk-Screening Environmental Indicators (RSEI) model</link1> from {date20} as compiled by EPA’s EJScreen`}
     description={'Navigate to the Methodology page. This is the source link for EPA RSEI'}
     values={{
-      link1: linkFn('https://www.epa.gov/ejscreen/technical-documentation-ejscreen', false, true),
+      link1: linkFn('https://www.epa.gov/ejscreen/download-ejscreen-data', false, true),
       date20: DATE_RANGE.TWENTY,
     }}
   />,

--- a/client/src/pages/tests/__snapshots__/methodology.test.tsx.snap
+++ b/client/src/pages/tests/__snapshots__/methodology.test.tsx.snap
@@ -1572,7 +1572,7 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                     <a
                       class="usa-link usa-link--external"
                       data-cy=""
-                      href="https://www.epa.gov/ejscreen/technical-documentation-ejscreen"
+                      href="https://www.epa.gov/ejscreen/download-ejscreen-data"
                       rel="noreferrer"
                       target="_blank"
                     >
@@ -2390,7 +2390,7 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                     <a
                       class="usa-link usa-link--external"
                       data-cy=""
-                      href="https://www.epa.gov/ejscreen/technical-documentation-ejscreen"
+                      href="https://www.epa.gov/ejscreen/download-ejscreen-data"
                       rel="noreferrer"
                       target="_blank"
                     >
@@ -2441,7 +2441,7 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                     <a
                       class="usa-link usa-link--external"
                       data-cy=""
-                      href="https://www.epa.gov/ejscreen/technical-documentation-ejscreen"
+                      href="https://www.epa.gov/ejscreen/download-ejscreen-data"
                       rel="noreferrer"
                       target="_blank"
                     >
@@ -2560,7 +2560,7 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                     <a
                       class="usa-link usa-link--external"
                       data-cy=""
-                      href="https://www.epa.gov/ejscreen/technical-documentation-ejscreen"
+                      href="https://www.epa.gov/ejscreen/download-ejscreen-data"
                       rel="noreferrer"
                       target="_blank"
                     >
@@ -2671,7 +2671,7 @@ exports[`rendering of the DatasetContainer checks if various text fields are vis
                     <a
                       class="usa-link usa-link--external"
                       data-cy=""
-                      href="https://www.epa.gov/ejscreen/technical-documentation-ejscreen"
+                      href="https://www.epa.gov/ejscreen/download-ejscreen-data"
                       rel="noreferrer"
                       target="_blank"
                     >


### PR DESCRIPTION
Our Cypress tests found a dead link to EJScreen's technical documentation (404). This PR fixes that dead link (in multiple places) and updates the associated test snapshots.